### PR TITLE
Fix typo: notifcations → notifications

### DIFF
--- a/src/AdminRoom.ts
+++ b/src/AdminRoom.ts
@@ -175,7 +175,7 @@ export class AdminRoom extends AdminRoomCommandHandler {
                 },
             };
         });
-        await this.sendNotice(`${newData.github?.notifications?.enabled ? "En" : "Dis"}abled GitHub notifcations`);
+        await this.sendNotice(`${newData.github?.notifications?.enabled ? "En" : "Dis"}abled GitHub notifications`);
     }
 
     @botCommand("github notifications filter participating", {help: "Toggle enabling/disabling GitHub notifications in this room", category: Category.Github})


### PR DESCRIPTION
Fixes a typo in the GitHub notifications toggle message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)