### PR TITLE
Documentation strategy and planning docs

### DIFF
--- a/doc/DOCUMENTATION_ARCHITECTURE.md
+++ b/doc/DOCUMENTATION_ARCHITECTURE.md
@@ -1,0 +1,1257 @@
+# Documentation Architecture for Matrix Hookshot
+
+---
+
+## 1. Core Documentation Philosophy
+
+### The guiding philosophy
+
+**Teach the machine, not the knobs.**
+
+Hookshot is not a collection of integrations — it is a programmable event bridge with a coherent architecture. The documentation must reveal that architecture. Every integration page, every config reference, every tutorial should reinforce the reader's mental model of how the system works as a whole. A reader who understands the model can predict behavior they haven't seen documented. A reader who only knows config keys is helpless the moment something unexpected happens.
+
+### What similar projects get wrong
+
+| Anti-pattern | Why it fails | What we do instead |
+|---|---|---|
+| **Config-first structure** — docs open with YAML | Reader has no model to hang config on; every key feels arbitrary | Architecture first, config as evidence of the model |
+| **Integration silos** — each service is its own world | Reader can't transfer knowledge between integrations; system feels incoherent | Shared integration model taught once, each service shown as an instance |
+| **Flat reference dump** — one giant page per topic | No reading path, no narrative, search-hostile | Layered: concept → guide → reference, each page does one job |
+| **Missing trust/failure model** — only happy paths | Operators can't reason about production behavior | Explicit sections for trust boundaries, failure modes, observability |
+| **External links as afterthoughts** — scattered or absent | Reader can't verify claims or go deeper | Curated external reference blocks on every relevant page |
+| **Single audience** — either too simple or too deep | Evaluators bounce, contributors starve | Persona-aware navigation with explicit reading paths |
+
+### The three laws of this documentation
+
+1. **Every page earns its existence** by serving exactly one purpose for an identifiable reader.
+2. **The system is the protagonist.** Integrations are characters in its story, not separate stories.
+3. **Evidence over assertion.** Every claim about behavior ships with a diagram, payload, or example.
+
+---
+
+## 2. Top-Level Documentation Architecture
+
+```
+hookshot-docs/
+│
+├── index.md                          ← Landing page with persona routing
+│
+├── understand/                       ← Mental model & architecture (read first)
+│   ├── what-is-hookshot.md
+│   ├── how-it-works.md
+│   ├── system-components.md
+│   ├── event-lifecycle.md
+│   ├── integration-model.md
+│   ├── trust-and-boundaries.md
+│   └── glossary.md
+│
+├── get-started/                      ← Time-to-value fast paths
+│   ├── quickstart.md
+│   ├── first-webhook.md
+│   ├── first-github-notification.md
+│   └── evaluate.md
+│
+├── guides/                           ← Task-oriented how-tos
+│   ├── user/                         ← For people using hookshot in rooms
+│   │   ├── connecting-a-room.md
+│   │   ├── bot-commands.md
+│   │   ├── widgets.md
+│   │   ├── notifications.md
+│   │   └── transformation-functions.md
+│   ├── operator/                     ← For people running hookshot
+│   │   ├── installation.md
+│   │   ├── configuration.md
+│   │   ├── registration.md
+│   │   ├── encryption.md
+│   │   ├── service-bots.md
+│   │   ├── workers-and-scaling.md
+│   │   ├── monitoring.md
+│   │   ├── upgrading.md
+│   │   └── hardening.md
+│   └── developer/                    ← For people building on hookshot
+│       ├── provisioning-api.md
+│       ├── webhook-api.md
+│       ├── widget-integration.md
+│       └── custom-transformations.md
+│
+├── integrations/                     ← Per-service pages (uniform template)
+│   ├── overview.md                   ← Capability matrix + integration model recap
+│   ├── github.md
+│   ├── gitlab.md
+│   ├── jira.md
+│   ├── generic-webhooks.md
+│   ├── feeds.md
+│   ├── figma.md
+│   ├── openproject.md
+│   └── challengehound.md
+│
+├── architecture/                     ← Deep internals for contributors & architects
+│   ├── overview.md
+│   ├── component-model.md
+│   ├── connections.md
+│   ├── state-and-storage.md
+│   ├── protocol-bridges.md
+│   ├── authentication-flows.md
+│   ├── message-pipeline.md
+│   ├── rust-typescript-boundary.md
+│   ├── extensibility.md
+│   └── failure-and-recovery.md
+│
+├── reference/                        ← Lookup tables (generated where possible)
+│   ├── configuration.md
+│   ├── bot-commands.md
+│   ├── provisioning-api.md
+│   ├── metrics.md
+│   ├── event-types.md
+│   ├── permissions.md
+│   ├── environment-variables.md
+│   └── matrix-spec-map.md
+│
+├── troubleshooting/                  ← Problem-first navigation
+│   ├── index.md
+│   ├── connection-issues.md
+│   ├── authentication.md
+│   ├── webhooks-not-arriving.md
+│   ├── encryption.md
+│   ├── performance.md
+│   └── common-errors.md
+│
+├── recipes/                          ← Copy-paste solutions
+│   ├── github-pr-to-matrix.md
+│   ├── gitlab-ci-notifications.md
+│   ├── jira-ticket-tracking.md
+│   ├── rss-news-feed.md
+│   ├── custom-webhook-transform.md
+│   └── multi-room-routing.md
+│
+├── external-references/              ← Curated upstream links
+│   ├── matrix-spec.md
+│   ├── github-api.md
+│   ├── gitlab-api.md
+│   ├── jira-api.md
+│   └── webhook-standards.md
+│
+├── project/                          ← Meta: roadmap, compatibility, contributing
+│   ├── roadmap.md
+│   ├── compatibility.md
+│   ├── changelog.md
+│   ├── limitations.md
+│   └── contributing.md
+│
+└── assets/
+    ├── diagrams/
+    ├── screenshots/
+    ├── videos/
+    └── payloads/
+```
+
+### Sidebar navigation grouping
+
+```yaml
+sidebar:
+  - group: "Understand"
+    icon: "lightbulb"
+    items: [understand/*]
+    collapsed: false
+
+  - group: "Get Started"
+    icon: "rocket"
+    items: [get-started/*]
+
+  - group: "Guides"
+    icon: "book"
+    items:
+      - group: "For Users"
+        items: [guides/user/*]
+      - group: "For Operators"
+        items: [guides/operator/*]
+      - group: "For Developers"
+        items: [guides/developer/*]
+
+  - group: "Integrations"
+    icon: "plug"
+    items: [integrations/*]
+
+  - group: "Architecture"
+    icon: "building"
+    items: [architecture/*]
+
+  - group: "Recipes"
+    icon: "flask"
+    items: [recipes/*]
+
+  - group: "Reference"
+    icon: "clipboard"
+    items: [reference/*]
+
+  - group: "Troubleshooting"
+    icon: "wrench"
+    items: [troubleshooting/*]
+
+  - group: "External References"
+    icon: "link"
+    items: [external-references/*]
+
+  - group: "Project"
+    icon: "pin"
+    items: [project/*]
+```
+
+---
+
+## 3. Section-by-Section Purpose
+
+### `understand/` — Mental Model
+
+| | |
+|---|---|
+| **For** | Every reader, especially first-time visitors |
+| **Problem it solves** | "I don't know what this system is or how to think about it" |
+| **Content** | Concepts, diagrams, the integration model, event lifecycle, trust boundaries, glossary |
+| **NOT here** | Config examples, setup steps, API references, troubleshooting |
+
+This section exists so that by the time a reader reaches any other section, they have a mental model that makes everything else predictable. The `event-lifecycle.md` page is the single most important page in the entire documentation — it shows how an event enters the system, gets routed, transformed, and delivered. The `integration-model.md` page teaches the abstraction that all integrations share (connection, event source, event sink, auth context, state) so that individual integration pages feel like instances, not islands.
+
+### `get-started/` — Time to Value
+
+| | |
+|---|---|
+| **For** | Evaluators, new admins, anyone impatient |
+| **Problem it solves** | "Can I get this running and see it work in under 10 minutes?" |
+| **Content** | Docker-compose quickstart, first webhook tutorial, first GitHub notification, evaluation checklist |
+| **NOT here** | Production deployment, full config reference, architecture |
+
+Every page in this section ends with a working result the reader can see. No page exceeds 5 minutes of effort. Each page links forward to the relevant deeper guide.
+
+### `guides/` — Task-Oriented How-Tos
+
+Three sub-audiences, strictly separated:
+
+**`guides/user/`** — For room moderators and team leads
+
+| | |
+|---|---|
+| **Problem it solves** | "How do I use hookshot features in my Matrix room?" |
+| **Content** | Connecting rooms, bot commands, widgets, notifications, writing transformation functions |
+| **NOT here** | Server configuration, deployment, API usage |
+
+**`guides/operator/`** — For admins running hookshot
+
+| | |
+|---|---|
+| **Problem it solves** | "How do I deploy, configure, secure, scale, and maintain hookshot?" |
+| **Content** | Installation, configuration walkthrough, appservice registration, encryption, monitoring, upgrades, hardening |
+| **NOT here** | End-user features, API development, architecture internals |
+
+**`guides/developer/`** — For platform developers building on hookshot
+
+| | |
+|---|---|
+| **Problem it solves** | "How do I integrate my system with hookshot's APIs?" |
+| **Content** | Provisioning API usage, webhook API, widget embedding, custom transformations |
+| **NOT here** | Internal architecture, deployment, end-user usage |
+
+### `integrations/` — Per-Service Pages
+
+| | |
+|---|---|
+| **For** | All audiences; the integration-specific entry point |
+| **Problem it solves** | "What does hookshot do with [GitHub/GitLab/JIRA/...]?" |
+| **Content** | Capabilities, architecture fit, auth model, event mapping, setup, examples, limitations, upstream links |
+| **NOT here** | General hookshot concepts (link to `understand/`), detailed config reference (link to `reference/`) |
+
+`overview.md` opens with a capability matrix — a table showing every integration x every capability (receive events, send commands, bidirectional sync, webhooks, OAuth, etc.). This single page answers the evaluator's #1 question.
+
+Every integration page follows the same template (Section 6). This consistency is a feature: readers learn the template once and can scan any integration fast.
+
+### `architecture/` — Deep Internals
+
+| | |
+|---|---|
+| **For** | Contributors, enterprise architects, curious operators |
+| **Problem it solves** | "How does hookshot actually work inside?" |
+| **Content** | Component model, connection abstraction, state management, protocol bridging, auth flows, message pipeline, Rust/TS boundary, extensibility, failure modes |
+| **NOT here** | Setup instructions, user-facing features, config reference |
+
+This is the section that makes architects say "these people know what they're doing." It reveals the system's elegance. See Section 5 for detailed structure.
+
+### `reference/` — Lookup Tables
+
+| | |
+|---|---|
+| **For** | Anyone who already knows what they're looking for |
+| **Problem it solves** | "What are the exact parameters / metrics / commands / event types?" |
+| **Content** | Complete config schema, every bot command, API endpoints, Prometheus metrics, permission model, environment variables, Matrix spec mapping |
+| **NOT here** | Explanations, tutorials, opinions |
+
+Pages here are exhaustive, tabular, and partially generated. `matrix-spec-map.md` maps every hookshot concept to the relevant Matrix spec section — this is unique and powerful.
+
+### `troubleshooting/` — Problem-First
+
+| | |
+|---|---|
+| **For** | Anyone with a broken setup |
+| **Problem it solves** | "Something isn't working and I need to fix it now" |
+| **Content** | Symptom-indexed pages, diagnostic steps, common errors with explanations, log reading guides |
+| **NOT here** | General setup (link back to guides), feature documentation |
+
+Every page opens with the symptom ("Webhooks arrive but no message appears in the room") and walks backward to causes.
+
+### `recipes/` — Copy-Paste Solutions
+
+| | |
+|---|---|
+| **For** | Anyone who wants a complete working example |
+| **Problem it solves** | "Show me exactly how to do [specific thing]" |
+| **Content** | End-to-end walkthroughs with full config, commands, and expected output |
+| **NOT here** | Concepts, partial examples, reference data |
+
+Each recipe is self-contained. A reader should be able to follow it without reading anything else (though links to concept pages are provided for context).
+
+### `external-references/` — Curated Upstream Links
+
+| | |
+|---|---|
+| **For** | Anyone who needs to understand the systems hookshot connects to |
+| **Problem it solves** | "Where do I find the GitHub/Matrix/JIRA docs relevant to what hookshot does?" |
+| **Content** | Curated, annotated link collections grouped by topic (auth, webhooks, events, rate limits, APIs) |
+| **NOT here** | Hookshot-specific documentation |
+
+This is not a link dump. Each page is organized by topic with a one-sentence annotation explaining why each link matters and what hookshot feature it relates to.
+
+### `project/` — Meta
+
+| | |
+|---|---|
+| **For** | Contributors, evaluators, enterprise decision-makers |
+| **Problem it solves** | "Where is this project going? What are its limits? How do I contribute?" |
+| **Content** | Roadmap, compatibility matrix, changelog, known limitations, contribution guide |
+| **NOT here** | Technical docs, setup, usage |
+
+---
+
+## 4. Recommended Reading Paths by Persona
+
+### Evaluator — "Should we use this?"
+```
+index.md
+  -> understand/what-is-hookshot.md
+  -> understand/how-it-works.md
+  -> integrations/overview.md          (capability matrix)
+  -> get-started/evaluate.md
+  -> get-started/quickstart.md         (try it)
+  -> project/compatibility.md
+  -> project/limitations.md
+```
+
+### Developer — "I need to integrate with this"
+```
+index.md
+  -> understand/what-is-hookshot.md
+  -> understand/integration-model.md
+  -> understand/event-lifecycle.md
+  -> guides/developer/provisioning-api.md
+  -> guides/developer/webhook-api.md
+  -> integrations/{relevant-service}.md
+  -> reference/provisioning-api.md
+  -> recipes/{relevant-recipe}.md
+```
+
+### Operator — "I need to run this in production"
+```
+index.md
+  -> understand/what-is-hookshot.md
+  -> understand/system-components.md
+  -> get-started/quickstart.md
+  -> guides/operator/installation.md
+  -> guides/operator/configuration.md
+  -> guides/operator/registration.md
+  -> integrations/{each-needed-service}.md  (setup sections)
+  -> guides/operator/monitoring.md
+  -> guides/operator/hardening.md
+  -> reference/configuration.md
+  -> reference/metrics.md
+  -> troubleshooting/
+```
+
+### Contributor — "I want to work on the code"
+```
+index.md
+  -> understand/how-it-works.md
+  -> understand/system-components.md
+  -> understand/event-lifecycle.md
+  -> architecture/overview.md
+  -> architecture/component-model.md
+  -> architecture/connections.md
+  -> architecture/rust-typescript-boundary.md
+  -> architecture/extensibility.md
+  -> project/contributing.md
+```
+
+### Enterprise Architect — "Does this fit our system?"
+```
+index.md
+  -> understand/what-is-hookshot.md
+  -> understand/trust-and-boundaries.md
+  -> architecture/overview.md
+  -> architecture/authentication-flows.md
+  -> architecture/failure-and-recovery.md
+  -> integrations/overview.md
+  -> guides/operator/workers-and-scaling.md
+  -> guides/operator/hardening.md
+  -> project/compatibility.md
+  -> project/limitations.md
+  -> reference/matrix-spec-map.md
+```
+
+---
+
+## 5. Internals and Architecture Section Design
+
+```
+architecture/
+├── overview.md                 ← System diagram, component inventory, 10,000ft view
+├── component-model.md          ← Every runtime component, its role, its boundaries
+├── connections.md              ← The Connection abstraction: lifecycle, state, types
+├── state-and-storage.md        ← Matrix state as primary store, Redis, caching
+├── protocol-bridges.md         ← How Matrix protocol maps to external protocols
+├── authentication-flows.md     ← OAuth flows, token lifecycle, trust delegation
+├── message-pipeline.md         ← Inbound and outbound message processing
+├── rust-typescript-boundary.md ← NAPI boundary, what lives where, why
+├── extensibility.md            ← How to add a new integration type
+└── failure-and-recovery.md     ← Failure modes, retry behavior, degradation
+```
+
+### Page-by-page design
+
+**`overview.md`** — The anchor page
+
+Opens with a full system diagram showing hookshot's position between Matrix homeserver and external services. Includes:
+- Component inventory table (name, responsibility, runtime location)
+- Data flow summary: inbound events -> hookshot -> Matrix rooms (and reverse)
+- Trust boundary diagram: what trusts what, where credentials live
+- Link to every sub-page
+
+```
+[Diagram: System context — hookshot between Matrix HS and external services]
+[Diagram: Component inventory — all runtime components and their relationships]
+```
+
+**`component-model.md`** — Runtime anatomy
+
+- The Bridge (entry point, Matrix event dispatch)
+- ConnectionManager (connection lifecycle, state derivation)
+- Connections (the abstraction, types, state machines)
+- Listeners (HTTP server for webhooks)
+- MessageQueue (internal async delivery)
+- StorageProviders (Redis, memory)
+- MatrixSender (outbound Matrix messages)
+- BotCommands (command parsing and dispatch)
+- Widgets (frontend provisioning UI)
+- Rust modules (performance-critical operations via NAPI)
+
+Each component: what it does, what it owns, what it depends on, what calls it.
+
+```
+[Diagram: Component dependency graph]
+[Diagram: Runtime process model — what runs in what thread/worker]
+```
+
+**`connections.md`** — The core abstraction
+
+This is the most important architecture page. Connections are hookshot's central idea.
+
+- What a Connection is (a bidirectional binding between a Matrix room and an external resource)
+- Connection lifecycle: creation -> configuration -> active -> updated -> removed
+- Connection state: stored as Matrix room state events
+- Connection types: the type hierarchy, shared interface, per-service specialization
+- How connections handle inbound events (external -> Matrix)
+- How connections handle outbound commands (Matrix -> external)
+- Connection provisioning: via bot commands, widgets, static config, API
+
+```
+[Diagram: Connection lifecycle state machine]
+[Diagram: Connection type hierarchy]
+[Sequence diagram: Inbound event through a connection]
+[Sequence diagram: Outbound command through a connection]
+```
+
+**`state-and-storage.md`**
+
+- Matrix room state as primary data store
+- What state events hookshot reads and writes
+- Redis as secondary store (feeds, caches, queues)
+- Memory-only storage for development
+- Startup: deriving connection state from room state
+- Consistency model: what happens during netsplits, restarts
+
+```
+[Diagram: State derivation on startup]
+[Table: State event types and their schemas]
+```
+
+**`protocol-bridges.md`**
+
+- How Matrix event types map to external event types
+- Bidirectional mapping tables per integration
+- Message format translation (Markdown, HTML, Matrix formatted body)
+- Attachment and media handling
+- Rate limiting and backpressure across protocol boundaries
+
+```
+[Table: Matrix event <-> GitHub event mapping]
+[Table: Matrix event <-> GitLab event mapping]
+[Table: Matrix event <-> JIRA event mapping]
+```
+
+**`authentication-flows.md`**
+
+- Appservice authentication (Matrix side)
+- Per-service auth models (OAuth 2.0, OAuth 1.0, tokens, API keys)
+- Token storage and encryption
+- Token refresh lifecycle
+- User-level vs. instance-level credentials
+- Trust delegation: when hookshot acts as a user vs. as a service
+
+```
+[Sequence diagram: GitHub App OAuth flow]
+[Sequence diagram: JIRA Cloud OAuth 2.0 flow]
+[Sequence diagram: GitLab token authentication]
+[Diagram: Trust delegation model]
+```
+
+**`message-pipeline.md`**
+
+- Inbound pipeline: HTTP webhook -> validation -> routing -> connection -> transformation -> Matrix send
+- Outbound pipeline: Matrix event -> command parse -> connection -> external API call
+- Transformation functions: the QuickJS sandbox, v1 vs v2 API, execution model
+- Message queue: async delivery, ordering, retry
+- Error handling at each pipeline stage
+
+```
+[Sequence diagram: Full inbound webhook pipeline]
+[Sequence diagram: Full outbound command pipeline]
+[Diagram: Transformation function sandbox model]
+```
+
+**`rust-typescript-boundary.md`**
+
+- What lives in Rust vs. TypeScript and why
+- The NAPI-rs interface
+- Data serialization across the boundary
+- Build process: how Rust compiles into the Node.js module
+- Performance characteristics
+- Adding new Rust modules
+
+```
+[Diagram: Rust/TypeScript module boundary]
+[Table: Current Rust modules and their purposes]
+```
+
+**`extensibility.md`**
+
+- How to add a new Connection type
+- The connection interface contract
+- Registering event handlers
+- Adding bot commands for a new service
+- Adding provisioning API endpoints
+- Adding widget UI for a new integration
+- Testing a new integration
+
+```
+[Code example: Minimal connection implementation skeleton]
+[Code example: Registering a new connection type]
+```
+
+**`failure-and-recovery.md`**
+
+- What happens when an external service is down
+- What happens when the Matrix homeserver is unreachable
+- Retry behavior and backoff
+- Message queue behavior during failures
+- State recovery on restart
+- Webhook delivery guarantees (at-least-once, ordering)
+- Feed polling failure and recovery
+- Monitoring failure: which metrics to alert on
+
+```
+[Table: Failure scenario x system behavior x recovery action]
+[Diagram: Retry and backoff model]
+```
+
+---
+
+## 6. Integration Documentation Model
+
+Every integration page follows this template. Consistency is non-negotiable.
+
+```markdown
+---
+title: "{Service Name} Integration"
+description: "Connect Matrix rooms to {Service Name} for {value prop}"
+audience: [user, operator, developer]
+integration: {service-slug}
+capabilities: [receive-events, send-commands, bidirectional, oauth, webhooks]
+status: stable | beta | deprecated
+---
+
+# {Service Name}
+
+> One-paragraph summary: what this integration does and why you'd use it.
+
+[Screenshot: Example Matrix message from this integration]
+
+## Capabilities
+
+| Capability | Supported | Notes |
+|---|---|---|
+| Receive events in Matrix | Y / N | |
+| Send commands from Matrix | Y / N | |
+| Bidirectional sync | Y / N | |
+| OAuth authentication | Y / N | |
+| Webhook-based | Y / N | |
+| Bot commands | Y / N | |
+| Widget UI | Y / N | |
+| Encryption compatible | Y / N | |
+
+## How it works
+
+Brief explanation in terms of the integration model.
+
+[Sequence diagram: Primary event flow]
+
+See [Integration Model](../understand/integration-model.md) for general context.
+
+## Supported events
+
+| External event | Matrix result | Direction |
+|---|---|---|
+| {event} | {result} | Inbound / Outbound |
+
+## Authentication
+
+How auth works for this integration.
+
+[Sequence diagram: Auth flow]
+
+External references:
+- [{Service} auth documentation]({url})
+- [{Service} permissions/scopes reference]({url})
+
+## Setup
+
+### Operator: Server-side configuration
+
+Step-by-step operator setup.
+
+[Code example: config.yml section]
+
+### User: Room-side connection
+
+How to connect a room.
+
+[Code example: Bot command]
+[Screenshot: Widget UI]
+
+## Example flows
+
+### {Flow 1 name}
+
+[Example payload: Incoming webhook payload]
+[Example payload: Resulting Matrix message]
+
+### {Flow 2 name}
+
+[Example payload: Matrix command]
+[Example payload: Resulting external API call]
+
+## Bot commands
+
+| Command | Description | Example |
+|---|---|---|
+| `!{prefix} {command}` | {description} | `{example}` |
+
+## Limitations
+
+- {Limitation 1}
+- {Limitation 2}
+
+## Troubleshooting
+
+| Symptom | Likely cause | See |
+|---|---|---|
+| {symptom} | {cause} | [{page}]({path}) |
+
+## Upstream references
+
+| Topic | Link |
+|---|---|
+| API documentation | [{Service} API docs]({url}) |
+| Webhook events | [{Service} webhook reference]({url}) |
+| Authentication | [{Service} auth guide]({url}) |
+| Rate limits | [{Service} rate limit docs]({url}) |
+
+## Related
+
+- [Integration Model](../understand/integration-model.md)
+- [Event Lifecycle](../understand/event-lifecycle.md)
+- [Config Reference]({config-section-link})
+- [Matrix Spec: Application Service API](https://spec.matrix.org/latest/application-service-api/)
+```
+
+---
+
+## 7. Reference and Evidence Placeholders
+
+### Placeholder conventions for authors
+
+Use HTML comments in the source to mark where rich assets belong:
+
+```
+<!-- ASSET: diagram — {filename} — {description} -->
+<!-- ASSET: screenshot — {filename} — {description} -->
+<!-- ASSET: sequence — {filename} — {description (Mermaid)} -->
+<!-- ASSET: video — {filename} — {description} -->
+<!-- ASSET: payload — {filename} — {description} -->
+<!-- ASSET: api-call — {filename} — {description} -->
+<!-- ASSET: matrix-event — {filename} — {description} -->
+<!-- ASSET: spec-link — {URL or MSC number} -->
+<!-- ASSET: external-link — {service} {doc-type} {URL} -->
+```
+
+### Asset filename conventions
+
+```
+assets/
+├── diagrams/
+│   ├── understand-system-context.svg
+│   ├── understand-event-lifecycle.mmd
+│   ├── architecture-component-model.svg
+│   ├── architecture-connection-lifecycle.mmd
+│   ├── integration-github-auth-flow.mmd
+│   └── ...
+├── screenshots/
+│   ├── get-started-quickstart-result.png
+│   ├── integration-github-room-message.png
+│   ├── guides-user-widget-ui.png
+│   └── ...
+├── videos/
+│   ├── get-started-quickstart.mp4
+│   └── ...
+└── payloads/
+    ├── github-pull-request-opened.json
+    ├── github-matrix-message-result.json
+    ├── gitlab-merge-request-webhook.json
+    └── ...
+```
+
+Pattern: `{section}-{slug}[-{qualifier}].{ext}`
+
+### Evidence density targets
+
+| Page type | Min diagrams | Min examples | Min screenshots |
+|---|---|---|---|
+| Concept page | 1 | 0 | 0 |
+| Integration overview | 1 | 2 | 1 |
+| Integration setup | 0 | 1 config snippet | 2 |
+| Tutorial | 1 sequence | 3 | 3 |
+| Architecture page | 2 | 1 | 0 |
+| Reference page | 0 | 1 per entry | 0 |
+| Recipe | 1 | 2 | 1 |
+| Troubleshooting | 0 | 1 per symptom | 0 |
+
+---
+
+## 8. Navigation and Cross-Linking Model
+
+### Page-level metadata
+
+Every page carries frontmatter metadata for filtering, navigation, and future tooling:
+
+```yaml
+---
+title: "Page Title"
+description: "One-line description"
+audience: [evaluator, user, operator, developer, contributor, architect]
+integration: github          # Optional
+component: connections       # Optional
+feature: webhooks           # Optional
+status: stable | beta | deprecated  # Optional
+prereqs: [path/to/page.md] # Optional, for tutorials
+time: "5 minutes"           # Optional, for tutorials
+generated: false            # Optional
+schema_source: "src/..."    # Optional, for generated content
+symptoms: ["error text"]    # Optional, for troubleshooting
+---
+```
+
+### Structured cross-reference blocks
+
+Every page ends with a structured "Related" section:
+
+```markdown
+## Related
+
+**Concepts**: [Connections](../understand/...) · [Event Lifecycle](../understand/...)
+**Guides**: [Configuration](../guides/operator/...)
+**Reference**: [Config](../reference/...) · [Bot Commands](../reference/...)
+**Troubleshooting**: [Webhooks Not Arriving](../troubleshooting/...)
+**Matrix Spec**: [Application Service API](https://spec.matrix.org/...)
+**External**: [GitHub Webhooks](https://docs.github.com/...)
+```
+
+### Inline cross-linking rules
+
+| When you mention... | Link to... |
+|---|---|
+| A hookshot concept | The relevant `understand/` page |
+| A config key | `reference/configuration.md#{anchor}` |
+| A bot command | `reference/bot-commands.md#{anchor}` |
+| A Matrix concept | The relevant Matrix spec section |
+| An external service concept | The relevant `external-references/` page |
+| A failure mode or error | The relevant `troubleshooting/` page |
+| An integration by name | `integrations/{service}.md` |
+
+### Contextual banners
+
+Pages primarily for one audience that are occasionally visited by another should include a contextual banner directing them to the right place.
+
+---
+
+## 9. Style and Editorial Rules
+
+### Tone
+- **Direct and confident.** Not "Hookshot can be used to..." but "Hookshot connects Matrix rooms to GitHub repositories."
+- **Technical without ceremony.** Assume the reader is competent.
+- **Precise.** "Hookshot sends an `m.room.message` event with `msgtype: m.notice`" — not "Hookshot sends a message."
+- **Active voice.** "Hookshot validates the webhook signature" not "The webhook signature is validated by hookshot."
+
+### Headings
+- H1: Page title only (one per page)
+- H2: Major sections
+- H3: Subsections
+- Never skip levels
+- Headings are noun phrases or imperative verbs: "Authentication", "Configure the GitHub App"
+
+### Diagrams
+- Mermaid for sequence diagrams and flowcharts (version-controlled, editable)
+- SVG for complex system diagrams
+- Every diagram has a caption
+- Color palette: blue for Matrix, green for hookshot, orange for external services, gray for infrastructure
+- No decorative diagrams — every diagram teaches something
+
+### Callouts
+
+```
+:::info          — Supplementary context
+:::tip           — Recommendations and best practices
+:::warning       — "This might bite you"
+:::danger        — "Data loss or security risk if you ignore this"
+:::note[...]     — Links to relevant specs or external docs
+```
+
+### Code examples
+- Always specify language for syntax highlighting
+- Use realistic values, not `foo`/`bar`
+- Config examples: show only the relevant section, link to full sample
+- CLI examples: show command AND expected output
+- Mark optional fields with comments
+
+### External systems
+- Never document how an external system works — link to their docs
+- Do document how hookshot interacts with that system
+- Cite specific external doc pages
+
+### Spec compliance
+- Be explicit: "Hookshot implements MSC1234" or "This follows the Application Service API"
+- If hookshot deviates or uses unstable features, say so clearly
+
+### Limitations
+- Never hide limitations
+- Pattern: "Hookshot does not currently support X. See #123 for tracking."
+- Group at the end of relevant pages
+
+---
+
+## 10. Showcase Pages — The "Hero Pages"
+
+The 10 most important pages that create the wow effect:
+
+### 1. `understand/event-lifecycle.md`
+The page that makes the entire system click. Full sequence diagram showing an event from external service through hookshot to Matrix room and back.
+
+### 2. `integrations/overview.md`
+Single capability matrix answering "what can hookshot do?" for every integration. What evaluators screenshot for their team.
+
+### 3. `understand/what-is-hookshot.md`
+First impression. System scope, elegance, value in under 2 minutes of reading. System context diagram.
+
+### 4. `architecture/overview.md`
+The page that makes architects trust the project. Full component diagram, trust boundaries, design decisions.
+
+### 5. `architecture/connections.md`
+The abstraction that makes hookshot coherent. Makes the Connection model feel inevitable.
+
+### 6. `get-started/quickstart.md`
+Docker-compose up, send a webhook, see it in Matrix. Under 5 minutes. Trust through experience.
+
+### 7. `architecture/authentication-flows.md`
+Auth is where integration systems feel solid or terrifying. Full sequence diagrams, explicit trust boundaries.
+
+### 8. `architecture/failure-and-recovery.md`
+"We've thought about what happens when things break." Failure scenario table with behavior and recovery.
+
+### 9. `reference/matrix-spec-map.md`
+Unique page mapping every hookshot concept to Matrix spec sections. Signals deep protocol understanding.
+
+### 10. `integrations/github.md`
+The richest integration, written to the full template. Sets the standard for all others.
+
+---
+
+## 11. Example Skeletons
+
+### Landing page (`index.md`)
+
+```markdown
+---
+title: Matrix Hookshot Documentation
+description: Connect Matrix to the tools your team uses
+---
+
+# Matrix Hookshot
+
+Hookshot is a Matrix application service that connects your Matrix rooms to
+external services — GitHub, GitLab, JIRA, RSS feeds, webhooks, and more.
+
+It receives events from external services and delivers them as Matrix messages.
+It accepts commands from Matrix rooms and executes them on external services.
+It is a programmable, extensible bridge between Matrix and everything else.
+
+<!-- DIAGRAM: System context -->
+
+## Choose your path
+
+| I want to... | Start here |
+|---|---|
+| Understand what hookshot does | What is Hookshot? |
+| Try it in 5 minutes | Quickstart |
+| Evaluate it for my organization | Evaluation Guide |
+| Set up a production deployment | Installation Guide |
+| Use hookshot in my Matrix rooms | User Guide |
+| Build on hookshot's APIs | Developer Guide |
+| Contribute to hookshot | Architecture Overview |
+| See what integrations are available | Integration Overview |
+```
+
+### Architecture overview skeleton
+
+```markdown
+---
+title: Architecture Overview
+description: How hookshot works internally
+audience: [contributor, architect]
+---
+
+# Architecture Overview
+
+Hookshot is a Node.js application service that registers with a Matrix homeserver
+via the Application Service API.
+
+## System context
+
+<!-- DIAGRAM: Full system context diagram -->
+
+## Component model
+
+<!-- DIAGRAM: Component dependency graph -->
+
+| Component | Responsibility | Key files |
+|---|---|---|
+| Bridge | Matrix event dispatch | src/Bridge.ts |
+| ConnectionManager | Connection lifecycle | src/ConnectionManager.ts |
+| ... | ... | ... |
+
+## Data flow
+
+### Inbound: External -> Matrix
+
+<!-- SEQUENCE_DIAGRAM: Inbound event flow -->
+
+### Outbound: Matrix -> External
+
+<!-- SEQUENCE_DIAGRAM: Outbound command flow -->
+
+## Key design decisions
+
+| Decision | Rationale |
+|---|---|
+| Matrix room state as primary storage | No external DB; state follows rooms |
+| One Connection class per integration | Isolated failure, independent development |
+| Rust for perf-critical paths | Feed parsing, crypto benefit from native speed |
+| QuickJS sandbox for transformations | Safe user code execution |
+```
+
+### Troubleshooting page skeleton
+
+```markdown
+---
+title: "Troubleshooting: Webhooks Not Arriving"
+description: Diagnose why external webhooks aren't producing Matrix messages
+audience: [operator, user]
+symptoms: ["no messages", "webhook 200 but nothing happens", "webhook 404"]
+---
+
+# Webhooks not arriving
+
+Checks ordered from most common to least common cause.
+
+## Check 1: Is the webhook URL correct?
+
+curl -v test and interpret the response:
+
+| Response | Meaning | Action |
+|---|---|---|
+| 200 ok | Hookshot received it | Continue to Check 2 |
+| 404 | URL doesn't match | Verify URL; recreate connection |
+| 401 | Secret mismatch | Check webhook secret config |
+| Connection refused | Hookshot not listening | Check process, port, firewall |
+
+## Check 2: Is the connection active?
+
+## Check 3: Is hookshot connected to the homeserver?
+
+## Check 4: Is the message being transformed away?
+
+## Check 5: Check hookshot metrics
+
+## Still stuck?
+```
+
+---
+
+## 12. Final Recommendation
+
+**Build the `understand/` section first.** Everything else is a leaf on that tree.
+
+The three highest-ROI pages to write first:
+
+1. **`understand/event-lifecycle.md`** — the single diagram that makes the system click
+2. **`integrations/overview.md`** — the capability matrix that sells the project
+3. **`architecture/connections.md`** — the abstraction that makes it coherent
+
+Then build outward: one integration page (GitHub) as reference implementation, one tutorial (first-webhook) as proof of simplicity, and the troubleshooting index as safety net.
+
+Do not write all pages at once. Ship the skeleton with navigation, write the hero pages, fill the rest iteratively. A well-structured doc site with 15 excellent pages beats a complete site with 40 mediocre ones.
+
+---
+
+## Appendix: Authoring Templates
+
+### A1. Concept Page Template
+
+```markdown
+---
+title: "{Concept Name}"
+description: "{One-line description}"
+audience: [evaluator, developer, operator, contributor, architect]
+---
+
+# {Concept Name}
+
+<!-- 2-3 sentence introduction -->
+
+## Overview
+
+<!-- High-level explanation -->
+<!-- DIAGRAM: {Concept} in context -->
+
+## How it works
+
+### {Sub-concept 1}
+
+<!-- Explanation -->
+<!-- CODE_EXAMPLE -->
+
+### {Sub-concept 2}
+
+<!-- Explanation -->
+<!-- SEQUENCE_DIAGRAM -->
+
+## Key properties
+
+- {Property 1}
+- {Property 2}
+
+## Examples
+
+<!-- PAYLOAD or MATRIX_EVENT examples -->
+
+## Common misconceptions
+
+<!-- Optional -->
+
+## Related
+
+- Concepts: ...
+- Guides: ...
+- Reference: ...
+- Matrix Spec: ...
+```
+
+### A2. Integration Page Template
+
+(See Section 6 for the full template)
+
+### A3. Tutorial Page Template
+
+```markdown
+---
+title: "Tutorial: {Task Name}"
+description: "{What the reader will accomplish}"
+audience: [evaluator, user, operator, developer]
+prereqs: [{list}]
+time: "{N} minutes"
+---
+
+# {Task Name}
+
+<!-- What you'll do and learn -->
+
+**Prerequisites**: {list with links}
+**Time**: ~{N} minutes
+
+## What you'll build
+
+<!-- DIAGRAM: End-state or flow -->
+
+## Step 1: {Action verb + object}
+
+<!-- Instructions, CODE_EXAMPLE, SCREENSHOT -->
+
+## Step 2: {Action verb + object}
+
+## Step N: {Final step}
+
+<!-- SCREENSHOT: Final result -->
+
+## What just happened
+
+1. {Explanation linking to concepts}
+2. ...
+
+## Next steps
+
+- [{Next tutorial}]({path})
+- [{Concept page}]({path})
+- [{Reference page}]({path})
+```
+
+### A4. Reference Page Template
+
+```markdown
+---
+title: "{Subject} Reference"
+description: "Complete reference for {subject}"
+audience: [operator, developer, contributor]
+generated: true | false
+---
+
+# {Subject} Reference
+
+<!-- One sentence: what this covers -->
+
+## {Category 1}
+
+| {Col 1} | {Col 2} | {Col 3} | {Col 4} |
+|---|---|---|---|
+
+### {Entry name}
+
+**Type**: `{type}`
+**Default**: `{default}`
+**Required**: yes / no
+**Since**: v{version}
+
+<!-- CODE_EXAMPLE: Usage example -->
+
+## Related
+
+- [{Concept page}]({path})
+- [{Guide}]({path})
+```
+
+### A5. Troubleshooting Page Template
+
+```markdown
+---
+title: "Troubleshooting: {Problem Area}"
+description: "Diagnose and fix {problem area} issues"
+audience: [operator, user]
+symptoms: ["{symptom 1}", "{symptom 2}"]
+---
+
+# {Problem Area}
+
+Work through these checks in order.
+
+## Check 1: {Most common cause}
+
+<!-- Diagnostic command -->
+
+| Result | Meaning | Action |
+|---|---|---|
+
+## Check 2: {Next most common}
+
+## Error messages
+
+| Error | Cause | Fix |
+|---|---|---|
+
+## Still stuck?
+
+- [Common errors](common-errors.md)
+- [GitHub issues]({url})
+- [Support channel]({url})
+```
+
+---
+
+## Appendix: Metadata Model
+
+```yaml
+---
+title: "Page Title"                    # Required
+description: "One-line description"    # Required
+audience:                              # Required
+  - evaluator | user | operator | developer | contributor | architect
+integration: github                    # Optional
+component: connections                 # Optional
+feature: webhooks                      # Optional
+status: stable | beta | deprecated     # Optional
+prereqs: [path/to/page.md]            # Optional
+time: "5 minutes"                      # Optional
+generated: false                       # Optional
+schema_source: "src/config/schema.ts"  # Optional
+symptoms: ["error text"]               # Optional
+---
+```
+
+### Naming conventions
+
+| Type | Pattern | Example |
+|---|---|---|
+| Concept pages | `{noun-phrase}.md` | `event-lifecycle.md` |
+| Guide pages | `{verb-or-noun-phrase}.md` | `installation.md` |
+| Integration pages | `{service-name}.md` | `github.md` |
+| Tutorial pages | `{task-slug}.md` | `first-webhook.md` |
+| Reference pages | `{subject}.md` | `configuration.md` |
+| Troubleshooting | `{problem-slug}.md` | `webhooks-not-arriving.md` |
+| Recipe pages | `{outcome-slug}.md` | `github-pr-to-matrix.md` |
+
+Rules:
+- Lowercase, hyphen-separated
+- No abbreviations unless universally understood (api, oauth)
+- No version numbers in filenames
+- Directories are plural nouns: `guides/`, `integrations/`, `recipes/`

--- a/doc/DOCUMENTATION_REVIEW.md
+++ b/doc/DOCUMENTATION_REVIEW.md
@@ -1,0 +1,453 @@
+# Documentation Architecture Review
+
+Editorial review of `DOCUMENTATION_ARCHITECTURE.md` — grounded in the actual codebase and current docs.
+
+---
+
+## 1. Editorial Philosophy
+
+**How this differs from typical OSS docs:**
+- Structure-first: teaches the system model before showing config
+- Evidence-required: every claim must trace to code, spec, or external docs
+- Audience-separated: no single page serves everyone poorly
+
+**What will be avoided:**
+- Config dumps without context
+- Idealized descriptions that don't match code behavior
+- Duplicated explanations across integration pages
+- Unmarked assumptions
+
+**What will be enforced:**
+- Every page declares its audience in frontmatter
+- Every integration page uses the same template
+- Claims include `[Code reference]` or are marked `[Assumption]`
+- Limitations are stated, not hidden
+
+---
+
+## 2. Reality Check of Current State
+
+Current docs live in `docs/` and are built with mdBook (`book.toml`).
+
+### Where readers get lost
+
+- **Setup pages mix operator and user concerns.** `docs/setup/github.md` (97 lines) covers GitHub App creation, webhook config, YAML config, AND OAuth — four distinct tasks for two different people on one page.
+- **No mental model.** A reader arrives at `docs/setup/github.md` without understanding what a "connection" is, how webhooks route to rooms, or what state events do. The setup page assumes knowledge it never provides.
+- **Usage docs are sparse.** `docs/usage/room_configuration/github_repo.md` (76 lines) is mostly a config options table. No event flow, no example messages, no troubleshooting.
+- **Only 3 of 8 integrations have room configuration docs** (GitHub, GitLab, JIRA). Feeds, webhooks, Figma, OpenProject, ChallengeHound have setup docs but no usage docs.
+
+### Where truth is unclear
+
+- **15 connection types exist in code** (`src/Connections/`), but docs don't enumerate them. A reader can't know what's possible.
+- **23 GitHub event types are configurable** (`src/Connections/GithubRepo.ts:144-170`), but docs list only event names without explaining what each produces in Matrix.
+- **Emoji reactions trigger GitHub actions** (close, reopen, approve PR) — completely undocumented.
+- **Legacy state event types** (e.g., `uk.half-shot.matrix-github.repository`) exist alongside current ones — migration path undocumented.
+- **The provisioning API** (`src/widgets/BridgeWidgetApi.ts:28-122`) has 12 endpoints — none documented as API reference.
+
+### Where structure fails
+
+- **`docs/SUMMARY.md` has 3 levels** but no conceptual foundation. It jumps from "Hookshot" overview straight to "Setup."
+- **No troubleshooting beyond one page.** `docs/troubleshooting.md` is a single file for all problems.
+- **No reference section.** Config, commands, metrics, event types — all undocumented as reference material.
+- **Advanced section is a grab-bag.** Workers, encryption, widgets, service bots — unrelated topics grouped by "not basic."
+
+---
+
+## 3. Target Structure Assessment
+
+### What works in the proposed structure
+
+- **`understand/` section is the right call.** The current docs' biggest gap is the missing mental model. Teaching connections, event lifecycle, and trust boundaries before anything else is correct.
+- **Separation of `guides/user/`, `guides/operator/`, `guides/developer/`** directly addresses the current problem of mixed audiences.
+- **`integrations/` with a uniform template** prevents the current inconsistency (GitHub has 2 doc pages, Figma has 1, feeds has 1).
+- **`reference/` section is overdue.** Config, commands, metrics, and event types are all extractable from code and should be lookup-optimized.
+- **`troubleshooting/` as symptom-indexed pages** replaces the current single-page catch-all.
+
+### What needs attention
+
+- **`understand/` has 7 pages — may be too many before readers reach anything actionable.** Consider: `what-is-hookshot.md` + `how-it-works.md` could merge. `system-components.md` overlaps with `architecture/component-model.md`.
+  - Recommendation: 4-5 concept pages max. Merge `what-is-hookshot` + `how-it-works`. Drop `system-components` (it belongs in `architecture/`).
+
+- **`integrations/` uses flat files (github.md, gitlab.md)** but GitHub alone has 6 connection types. A flat file will be 500+ lines.
+  - Recommendation: Allow subdirectories for complex integrations: `integrations/github/index.md`, `integrations/github/repos.md`, `integrations/github/issues.md`. Keep flat files for simple ones (feeds, figma).
+
+- **`external-references/` may not earn its existence.** Curated links are valuable but a standalone section may go unvisited. External links work better inline + in integration page footers.
+  - Recommendation: Demote to a single `reference/external-links.md` page or merge into integration pages.
+
+- **`recipes/` vs `guides/` boundary is fuzzy.** "Bridge a GitHub org" is both a recipe and a guide.
+  - Recommendation: Recipes are multi-integration or compound tasks. Guides are single-feature. Make this explicit.
+
+### Overlap check
+
+| Page A | Page B | Overlap | Resolution |
+|---|---|---|---|
+| `understand/system-components` | `architecture/component-model` | High | Drop from understand/ |
+| `understand/trust-and-boundaries` | `architecture/authentication-flows` | Medium | understand/ = concept, architecture/ = implementation |
+| `guides/operator/configuration` | `reference/configuration` | Medium | guide = walkthrough, reference = lookup. Clear. |
+| `integrations/github` setup section | `guides/operator/` | Low | Integration setup is service-specific; operator guide is general |
+
+---
+
+## 4. Evidence Model
+
+### Required evidence by page type
+
+| Page type | Code refs | Config examples | Payloads | Spec links | External links |
+|---|---|---|---|---|---|
+| Concept | Required | Optional | Optional | Required where relevant | Optional |
+| Integration | Required | Required | Required | Required | Required |
+| Operator guide | Optional | Required | N/A | Optional | Optional |
+| User guide | Optional | Required (commands) | Optional | N/A | N/A |
+| Reference | Required (source file) | Required | Required where relevant | Required | Required |
+| Troubleshooting | Optional | Required (diagnostic) | Optional | N/A | N/A |
+| Tutorial | Optional | Required | Required | N/A | Optional |
+
+### How evidence is displayed
+
+```markdown
+<!-- Inline code reference -->
+[Code: src/Connections/GithubRepo.ts:144-170]
+
+<!-- Inline spec reference -->
+[Matrix Spec: Application Service API](https://spec.matrix.org/latest/application-service-api/)
+
+<!-- Evidence block for claims -->
+> **Source:** Observed in `src/Bridge.ts:319-325` — `bindHandlerToQueue` maps
+> `github.issues.opened` to `GitHubRepoConnection.onIssueCreated()`.
+```
+
+### Keeping evidence current
+
+- Code references include file + line range. CI can check if referenced files still exist.
+- Config examples are extracted from `config.sample.yml` or tested against schema.
+- Payload examples are stored as JSON in `assets/payloads/` and validated in CI.
+- External links are checked weekly via link checker.
+
+---
+
+## 5. Traceability Model
+
+### Reference format
+
+Every significant claim uses one of:
+
+```
+[Code: src/path/File.ts:line-range]          — links to source
+[Config: config.sample.yml#section]          — links to config
+[Issue: #number]                              — links to GitHub issue
+[Spec: MSC1234 or spec-section-url]          — links to Matrix spec
+[External: service-name — doc-topic](url)    — links to upstream docs
+[Assumption — needs verification]             — marks uncertainty
+[Observed: description]                       — empirical finding
+```
+
+### Linking strategy
+
+- Internal links: relative paths (`../understand/connections.md`)
+- Code links: file path + line numbers (can be GitHub permalink in rendered docs)
+- Spec links: always to `latest/` unless version-specific
+- External links: to stable/permanent URLs, not blog posts
+
+### Avoiding broken trust
+
+- Never claim "hookshot does X" without code or behavioral evidence
+- If code behavior is ambiguous, say so: "Based on `Bridge.ts:319`, hookshot appears to..."
+- If a feature is partially implemented, state the limitation
+- If external API behavior is assumed, link to their docs
+
+---
+
+## 6. Issue & Subtask Breakdown
+
+### Issue 1: Create mental model pages (understand/)
+
+**Goal:** Readers can explain hookshot's architecture after reading 4 pages.
+**Outcome:** `understand/` section with: what-is-hookshot, event-lifecycle, integration-model, trust-and-boundaries, glossary.
+**Why:** Current docs have zero conceptual foundation.
+
+Subtasks:
+- [ ] Write `understand/what-is-hookshot.md` — system context diagram, one-paragraph positioning. Source: `src/Bridge.ts` startup flow, `DOCUMENTATION_ARCHITECTURE.md` section 5.
+- [ ] Write `understand/event-lifecycle.md` — inbound + outbound sequence diagrams. Source: `src/Bridge.ts:300-500` handler bindings, `src/Webhooks.ts` routing.
+- [ ] Write `understand/integration-model.md` — the Connection abstraction. Source: `src/Connections/IConnection.ts:30-117`, `src/Connections/BaseConnection.ts`.
+- [ ] Write `understand/trust-and-boundaries.md` — auth model overview. Source: GitHub OAuth in `src/github/GithubInstance.ts`, JIRA OAuth, appservice auth.
+- [ ] Write `understand/glossary.md` — define: connection, state event, appservice, bridge, hook, transformation.
+
+### Issue 2: Build the integration template and write GitHub page
+
+**Goal:** One complete integration page that sets the quality bar.
+**Outcome:** `integrations/github.md` following the template, with all evidence blocks filled.
+**Why:** GitHub is the richest integration (6 connection types, 23 events, 4 bot commands, emoji reactions).
+
+Subtasks:
+- [ ] Finalize integration template (from DOCUMENTATION_ARCHITECTURE.md section 6)
+- [ ] Write capabilities table — verified against `src/Connections/Github*.ts`
+- [ ] Document all 23 event types with their Matrix message format. Source: `src/Connections/GithubRepo.ts:1114-1787`
+- [ ] Document auth flows with sequence diagrams. Source: `src/github/GithubInstance.ts`, `src/github/AdminCommands.ts`
+- [ ] Document bot commands. Source: `@botCommand` decorators in `GithubRepo.ts:922-1112`
+- [ ] Document emoji reaction mappings (currently undocumented)
+- [ ] Create example payloads (GitHub webhook → Matrix message)
+- [ ] List limitations and link to relevant issues
+
+### Issue 3: Create reference section (partially generated)
+
+**Goal:** Lookup-optimized pages for config, commands, metrics, event types.
+**Outcome:** `reference/` section with 5+ pages.
+**Why:** No reference documentation currently exists.
+
+Subtasks:
+- [ ] Write script to extract `@botCommand` metadata → `reference/bot-commands.md`
+- [ ] Write script to extract config schema from `src/config/Config.ts:123-251` → `reference/configuration.md`
+- [ ] Catalog all `uk.half-shot.matrix-hookshot.*` state events → `reference/event-types.md`
+- [ ] Document all Prometheus metrics from `src/Metrics.ts` → `reference/metrics.md`
+- [ ] Document provisioning API endpoints from `src/widgets/BridgeWidgetApi.ts:28-122` → `reference/provisioning-api.md`
+- [ ] Create `reference/matrix-spec-map.md` — map hookshot concepts to spec sections
+
+### Issue 4: Restructure operator guides
+
+**Goal:** Operators have a clear path from install to production.
+**Outcome:** `guides/operator/` with installation, configuration, registration, monitoring, upgrading.
+**Why:** Current setup/ section mixes operator and user concerns.
+
+Subtasks:
+- [ ] Migrate `docs/setup.md` → `guides/operator/installation.md` (operator parts only)
+- [ ] Migrate `docs/setup/sample-configuration.md` → `guides/operator/configuration.md` (with walkthrough)
+- [ ] Write `guides/operator/registration.md` — appservice registration for Synapse/Dendrite
+- [ ] Migrate `docs/metrics.md` + `docs/sentry.md` → `guides/operator/monitoring.md`
+- [ ] Migrate `docs/advanced/workers.md` → `guides/operator/workers-and-scaling.md`
+- [ ] Migrate `docs/advanced/encryption.md` → `guides/operator/encryption.md`
+- [ ] Write `guides/operator/upgrading.md` — version migration notes (currently missing)
+
+### Issue 5: Create quickstart and tutorials
+
+**Goal:** New users get a working setup in 5 minutes.
+**Outcome:** `get-started/` section with quickstart + 2 tutorials.
+**Why:** No quickstart exists. Current docs require reading 3+ pages before anything works.
+
+Subtasks:
+- [ ] Write `get-started/quickstart.md` — docker-compose, minimal config, one webhook
+- [ ] Write `get-started/first-webhook.md` — end-to-end generic webhook tutorial
+- [ ] Write `get-started/evaluate.md` — feature matrix, comparison, limitations
+
+### Issue 6: Build troubleshooting section
+
+**Goal:** Operators can diagnose common failures without asking for help.
+**Outcome:** `troubleshooting/` with symptom-indexed pages.
+**Why:** Current `troubleshooting.md` is a single page for all problems.
+
+Subtasks:
+- [ ] Write `troubleshooting/webhooks-not-arriving.md`
+- [ ] Write `troubleshooting/authentication.md`
+- [ ] Write `troubleshooting/connection-issues.md`
+- [ ] Write `troubleshooting/common-errors.md` — extract from GitHub issues
+- [ ] Write `troubleshooting/index.md` — symptom → page routing table
+
+### Issue 7: Migrate remaining integration pages
+
+**Goal:** All 8 integrations documented to template.
+**Outcome:** `integrations/` complete for GitLab, JIRA, webhooks, feeds, Figma, OpenProject, ChallengeHound.
+
+Subtasks (one per integration):
+- [ ] `integrations/gitlab.md` — Source: `src/Connections/GitlabRepo.ts`, `src/Connections/GitlabIssue.ts`
+- [ ] `integrations/jira.md` — Source: `src/Connections/JiraProject.ts`, `src/jira/`
+- [ ] `integrations/generic-webhooks.md` — Source: `src/Connections/GenericHook.ts`, `src/Connections/OutboundHook.ts`
+- [ ] `integrations/feeds.md` — Source: `src/Connections/FeedConnection.ts`, Rust feed parser
+- [ ] `integrations/figma.md` — Source: `src/Connections/FigmaFileConnection.ts`
+- [ ] `integrations/openproject.md` — Source: `src/Connections/OpenProjectConnection.ts`
+- [ ] `integrations/challengehound.md` — Source: `src/Connections/HoundConnection.ts`
+- [ ] `integrations/overview.md` — Capability matrix across all integrations
+
+---
+
+## 7. Page Construction Rules
+
+Every page MUST include:
+
+1. **Frontmatter** with title, description, audience, and relevant tags
+2. **Opening sentence** that says what this page helps you do (not what it "covers")
+3. **Core content** — no filler paragraphs. Every paragraph adds information.
+4. **At least one evidence block** — code reference, example, or external link
+5. **Related section** at the bottom — structured links to concept, guide, reference, troubleshooting pages
+6. **Limitations/unknowns section** (where applicable) — what this page doesn't cover and why
+
+Every page MUST NOT include:
+
+- Paragraphs that restate the heading
+- "In this section, we will..." preamble
+- Undocumented claims about behavior
+- Config examples without explaining what they do
+- External links without context on why they're relevant
+
+---
+
+## 8. Integration Pages Assessment
+
+The proposed template in DOCUMENTATION_ARCHITECTURE.md Section 6 is strong. Gaps:
+
+### Missing from current template
+
+- **Emoji reaction mappings** — GitHub (and possibly others) support reaction-to-action mappings. Not in template.
+  - Fix: Add "Reactions" section between "Bot commands" and "Limitations"
+
+- **Connection types enumeration** — GitHub has 6 connection types, not just "repository." Template assumes one connection per integration.
+  - Fix: Add "Connection types" table at the top, before "Capabilities"
+
+- **Message format examples** — Template says "[Example payload]" but doesn't specify: show the Matrix `m.room.message` event content including the custom `uk.half-shot.*` metadata fields.
+  - Fix: Require full Matrix event JSON, not just the formatted body
+
+- **Default vs. opt-in events** — Template lists events but doesn't distinguish defaults from opt-in.
+  - Fix: Add "Default" column to events table (as done in Round 1 GitHub draft)
+
+- **Static connection config** — Template covers bot commands and widget UI for connection creation, but not static YAML config or direct state event manipulation.
+  - Fix: Add "Static connections" subsection under Setup
+
+### What the template gets right
+
+- Capabilities table with consistent columns
+- Sequence diagram for primary flow
+- Auth section with upstream links
+- Troubleshooting scoped to this integration
+- Upstream references table
+- Related section at bottom
+
+---
+
+## 9. Readability Rules
+
+- **Sentence length:** 25 words max guideline. If you need a comma, consider splitting.
+- **Paragraph size:** 3-4 sentences max. One idea per paragraph.
+- **Use bullets when:** listing 3+ items, enumerating steps, comparing options.
+- **Use tables when:** showing structured data with 2+ dimensions (events, capabilities, config keys).
+- **Use diagrams when:** showing flow (sequence), relationships (component), or state (lifecycle). Never for decoration.
+- **Use code blocks when:** showing exact syntax, commands, payloads, or config. Always specify language.
+- **Heading style:** Noun phrases ("Authentication") or imperatives ("Configure the GitHub App"). Never questions ("How do I configure?") in headings — questions belong in troubleshooting.
+- **Active voice always.** "Hookshot validates the signature" not "The signature is validated."
+- **No hedging.** "Hookshot sends a message" not "Hookshot will attempt to send a message." If behavior is conditional, state the condition.
+
+---
+
+## 10. "Proof Over Promise" Rules
+
+### Assumptions presented as facts
+- Before writing "hookshot does X": grep for it, read the code, confirm
+- If unconfirmed: write "Based on `src/File.ts:line`, hookshot appears to X. [Needs verification]"
+- Never claim support for something based on config key existence alone — config keys can be dead code
+
+### Outdated claims
+- Every page that references code includes file paths. When code changes, search finds affected pages.
+- Pages with `last_verified` frontmatter field — stale after 6 months, flagged in CI
+- Config examples tested against current schema in CI
+
+### Undocumented features
+- Before documenting a feature, verify it works (or mark as "not verified")
+- Emoji reactions in GitHub integration: undocumented because no one checked the code. This is the default failure mode. The antidote: code-reading sessions that feed docs.
+
+---
+
+## 11. Example Rewrite
+
+### Current: `docs/setup/github.md` (excerpt)
+
+> You will need to create a GitHub App. You should give it:
+>
+> A unique name and homepage (this doesn't matter, it can be anything you like)
+>
+> Webhook URL should be the public address of the hookshot listener, with the path of /github/webhook.
+
+### Rewritten
+
+```markdown
+## Create a GitHub App
+
+Hookshot authenticates with GitHub as a [GitHub App](https://docs.github.com/en/apps).
+You need one App per hookshot instance.
+
+1. Go to your GitHub org → Settings → Developer settings → GitHub Apps → New GitHub App
+2. Set:
+   - **Name**: anything unique (e.g., `my-hookshot`)
+   - **Homepage URL**: your hookshot URL (cosmetic only)
+   - **Webhook URL**: `https://<hookshot-host>/github/webhook`
+   - **Webhook secret**: generate one (`openssl rand -hex 32`)
+
+3. Under Permissions, enable:
+
+   | Category | Permission | Access |
+   |---|---|---|
+   | Repository | Actions | Read-only |
+   | Repository | Contents | Read-only |
+   | Repository | Discussions | Read & write |
+   | Repository | Issues | Read & write |
+   | Repository | Metadata | Read-only |
+   | Repository | Projects | Read-only |
+   | Repository | Pull requests | Read & write |
+   | Organization | Team discussions | Read & write |
+
+   [Code: permissions checked in src/github/GithubInstance.ts]
+   [External: GitHub App permissions reference](https://docs.github.com/en/apps/creating-github-apps/setting-permissions-for-github-apps)
+
+4. Subscribe to webhook events:
+
+   commit_comment, create, delete, discussion, discussion_comment,
+   issue_comment, issues, project, project_card, project_column,
+   pull_request, pull_request_review, pull_request_review_comment,
+   push, release, repository, workflow_run
+
+   [Code: handled in src/github/Router.ts and src/Bridge.ts:300-500]
+
+5. After creation, note the **App ID** and download the **private key** (.pem file).
+
+6. Add to `config.yml`:
+
+   ```yaml
+   github:
+     auth:
+       id: 12345                    # App ID from step 5
+       privateKeyFile: github.pem   # Path to private key from step 5
+     webhook:
+       secret: "your-secret"        # Secret from step 2
+   ```
+
+   [Config: src/config/sections/GitHub.ts:1-68]
+
+**What happens next:** When hookshot starts, it authenticates as the GitHub App
+and listens for webhooks at `/github/webhook`. Webhook payloads are verified
+using the HMAC-SHA256 signature in the `x-hub-signature-256` header.
+[Code: src/github/Router.ts:74-99]
+```
+
+---
+
+## 12. Final Summary
+
+**What makes this documentation trustworthy:**
+- Every claim traces to code, spec, or external documentation
+- Uncertainty is marked, not hidden
+- Structure matches how people actually need information (by task and role, not by internal module)
+
+**Why developers will actually read it:**
+- Mental model pages mean they understand *why* before they see *how*
+- Integration pages follow a predictable template — learn the format once, scan any service fast
+- Reference pages are lookup-optimized — no reading required, just search
+- Troubleshooting starts from symptoms, not from system internals
+
+---
+
+## Appendix: Template Improvements
+
+### Additions to concept page template
+- Add `## What this does NOT cover` section
+- Add `## Prerequisites` (which concept pages should be read first)
+
+### Additions to integration page template
+- Add `## Connection types` table (before Capabilities)
+- Add `## Reactions` section (after Bot commands)
+- Add `## Static connections` subsection under Setup
+- Require full Matrix event JSON in example payloads
+- Add "Default" column to events table
+
+### Additions to troubleshooting template
+- Add `## Before you start` — basic diagnostic checklist (is hookshot running, can you see logs)
+- Add `## Collect this information` — what to gather before filing a bug
+
+### Additions to tutorial template
+- Add `## If something went wrong` — common failure points for each step
+- Add estimated time for each step, not just total

--- a/doc/DOCUMENTATION_TOOLING.md
+++ b/doc/DOCUMENTATION_TOOLING.md
@@ -1,0 +1,566 @@
+# Documentation Tooling & Automation Strategy
+
+---
+
+## 1. Failure Analysis
+
+### How documentation breaks over time
+
+| Failure mode | How it happens | Why hard to detect | Impact on trust |
+|---|---|---|---|
+| **Technical drift** | Code changes, docs don't update. A config key is renamed, a handler removed, an event type added. | No automated link between code and docs. PR reviewers focus on code, not docs. | Reader follows docs, gets an error. Immediate trust loss. |
+| **Structural drift** | New pages don't follow the template. Sections get added ad-hoc. Naming conventions ignored. | No schema validation for page structure. Inconsistency accumulates gradually. | Site feels disorganized. Readers can't predict where to find things. |
+| **Outdated examples** | Config examples reference old keys. API call examples use deprecated endpoints. Payload formats change. | Examples aren't executed. They're strings in markdown, not tested code. | Reader copies example, it fails. Most damaging failure mode. |
+| **Broken links** | Pages renamed, headings changed, external URLs moved. | No one clicks every link. Internal restructuring breaks cross-references silently. | Dead links signal abandonment. |
+| **Missing integrations** | New connection type added to code, no docs written. | No coverage check. Code PRs don't require doc PRs. | Feature is invisible to users. |
+| **Partial documentation** | Page exists but is incomplete. "TODO" markers, empty sections, placeholder text. | Partially-written pages look complete in the sidebar. | Reader navigates to page, finds nothing useful. |
+| **Copy-paste divergence** | Same concept explained in 3 places. One gets updated, others don't. | No single source of truth enforcement. grep catches exact matches but not paraphrases. | Contradictory information. Reader doesn't know which to trust. |
+| **Undocumented features** | Feature implemented but never written up. Emoji reactions in GitHub integration, for example. | No inventory check comparing code features to documented features. | Power users discover features by reading source code. Others never find them. |
+| **Stale external references** | GitHub changes their API docs URL. Matrix spec section renamed. | External URL checks catch 404s but not moved content. | Links go nowhere or to wrong content. |
+
+---
+
+## 2. Automation Strategy
+
+### Per-failure-type response
+
+| Failure | Automated detection | Automated prevention | Manual fallback |
+|---|---|---|---|
+| Technical drift | CI: grep referenced file paths in docs, check they exist | PR template: "Does this change affect docs?" checkbox | Quarterly doc-code audit |
+| Structural drift | CI: validate frontmatter schema, check required sections per page type | PR lint: `markdownlint` + custom rules | Template review in PR |
+| Outdated examples | CI: validate config examples against schema, test API examples | Generate config reference from `@configKey` decorators | Manual review of examples quarterly |
+| Broken links | CI: `lychee` link checker (internal + external) | Pre-commit hook for internal links | Weekly external link check |
+| Missing integrations | CI: compare `src/Connections/` file list to `docs/integrations/` file list | PR bot comment: "New connection type detected, no docs found" | Track in issue per integration |
+| Partial docs | CI: check required sections present per page type template | Minimum content length per section | Review checklist |
+| Copy-paste divergence | N/A (hard to automate) | Single source of truth: concept pages linked from integration pages, never duplicated | Review guideline: "link, don't repeat" |
+| Undocumented features | CI: extract `@botCommand` count vs documented commands count | Generate reference pages from code decorators | Feature inventory audit |
+| Stale external refs | Weekly CI: external link checker with status reporting | Pin to versioned external URLs where possible | Manual review of flagged links |
+
+---
+
+## 3. Documentation as Code Model
+
+### Repo structure
+
+Docs live in the same repo as code (current: `docs/`, proposed: keep in-repo).
+
+```
+matrix-hookshot/
+├── docs/                          # Documentation source
+│   ├── understand/
+│   ├── get-started/
+│   ├── guides/
+│   ├── integrations/
+│   ├── architecture/
+│   ├── reference/
+│   ├── troubleshooting/
+│   ├── recipes/
+│   ├── external-references/
+│   ├── project/
+│   ├── assets/
+│   └── SUMMARY.md                 # Navigation (mdBook) or sidebar config
+├── scripts/
+│   ├── build-metrics-docs.ts      # Existing: generates metrics.md
+│   ├── build-config-docs.ts       # New: generates config reference
+│   ├── build-commands-docs.ts     # New: generates bot commands reference
+│   └── build-events-docs.ts       # New: generates event types reference
+└── .github/
+    └── workflows/
+        ├── docs-latest.yml        # Existing: build + deploy docs on push to main
+        ├── docs-release.yml       # Existing: versioned release docs
+        └── docs-lint.yml          # New: lint + validate on PR
+```
+
+**Why in-repo:** Code changes and doc changes should be in the same PR. Separate repos create drift by design.
+
+### Versioning strategy
+
+- `docs-latest.yml` publishes from `main` → latest docs (current behavior)
+- `docs-release.yml` publishes tagged releases → versioned docs (current behavior)
+- Breaking changes: doc migration notes in `docs/project/upgrading.md`
+
+### Branching model
+
+- Doc changes go on the same branch as code changes
+- Doc-only changes: branch from `main`, small PRs
+- Large restructuring: tracked as GitHub issue, can span multiple PRs
+
+### Review process
+
+- PRs touching `docs/` require review from a docs-aware maintainer
+- Add to `CODEOWNERS`:
+  ```
+  /docs/ @hookshot-docs-team
+  /scripts/build-*-docs.ts @hookshot-docs-team
+  ```
+- PR template includes: "Documentation: [ ] Updated [ ] Not needed [ ] New page created"
+
+### Quality enforcement in PRs
+
+MUST (CI-enforced):
+- Frontmatter validates against schema
+- Internal links resolve
+- Required sections present per page type
+- No broken Mermaid diagrams
+- markdownlint passes
+
+SHOULD (reviewer-enforced):
+- Evidence blocks present
+- External links annotated
+- Code references accurate
+- Tone matches editorial rules
+
+---
+
+## 4. Structured Metadata System
+
+### Frontmatter schema
+
+```yaml
+---
+title: "Page Title"                     # REQUIRED
+description: "One-line description"     # REQUIRED
+audience:                               # REQUIRED, one or more
+  - user | operator | developer | contributor | architect | evaluator
+integration: github                     # OPTIONAL, service slug
+component: connections                  # OPTIONAL, system component
+feature: webhooks                       # OPTIONAL, feature area
+status: current | draft | deprecated    # REQUIRED, default "current"
+last_verified: "2026-04-01"            # OPTIONAL, for time-sensitive content
+generated_from: "src/Metrics.ts"        # OPTIONAL, for auto-generated pages
+prereqs:                                # OPTIONAL, for tutorials
+  - understand/connections.md
+time: "5 minutes"                       # OPTIONAL, for tutorials
+---
+```
+
+### Validation
+
+CI script validates:
+```typescript
+// scripts/validate-frontmatter.ts
+const REQUIRED_FIELDS = ['title', 'description', 'audience', 'status'];
+const VALID_AUDIENCES = ['user', 'operator', 'developer', 'contributor', 'architect', 'evaluator'];
+const VALID_STATUSES = ['current', 'draft', 'deprecated'];
+const VALID_INTEGRATIONS = ['github', 'gitlab', 'jira', 'webhooks', 'feeds', 'figma', 'openproject', 'challengehound'];
+```
+
+### How metadata is used
+
+- **Navigation filtering:** Sidebar can group by audience or integration
+- **Staleness detection:** `last_verified` older than 6 months → CI warning
+- **Coverage reporting:** Which integrations have docs? Which audiences are underserved?
+- **Search facets:** Tag-based filtering in search results
+
+---
+
+## 5. Evidence Enforcement
+
+### Required evidence per page type
+
+| Page type | Code ref | Config example | Payload example | Spec link | External link |
+|---|---|---|---|---|---|
+| Concept | SHOULD | OPTIONAL | OPTIONAL | MUST (where relevant) | OPTIONAL |
+| Integration | MUST | MUST | MUST | MUST | MUST |
+| Operator guide | OPTIONAL | MUST | N/A | OPTIONAL | OPTIONAL |
+| Tutorial | OPTIONAL | MUST | MUST | N/A | OPTIONAL |
+| Reference | MUST (source file) | MUST | MUST (where relevant) | MUST | MUST |
+| Troubleshooting | OPTIONAL | MUST (diagnostic) | OPTIONAL | N/A | N/A |
+
+### CI enforcement
+
+```typescript
+// scripts/validate-evidence.ts
+const INTEGRATION_REQUIRED_SECTIONS = [
+  'Capabilities',
+  'How it works',
+  'Authentication',
+  'Setup',
+  'Bot commands',
+  'Limitations',
+  'Upstream references',
+  'Related',
+];
+
+// Check: integration pages must contain at least one code reference
+// Pattern: [Code: src/...] or ```yaml (config example)
+```
+
+### Lint rules (custom markdownlint)
+
+- `hookshot/evidence-block`: Integration pages must contain `[Code:` pattern
+- `hookshot/upstream-refs`: Integration pages must contain `## Upstream references`
+- `hookshot/limitations`: Integration pages must contain `## Limitations`
+- `hookshot/related`: All pages must contain `## Related`
+
+---
+
+## 6. Example Validation System
+
+### What exists today
+
+- `scripts/build-metrics-docs.ts` — generates `docs/metrics.md` from `prom-client` registry
+  - Imports `Metrics` singleton, reads registered metrics, outputs markdown table
+  - [Code: `scripts/build-metrics-docs.ts:1-30`]
+- This is the ONLY auto-generated doc page currently
+
+### What to build
+
+**Config reference generation:**
+```typescript
+// scripts/build-config-docs.ts
+// Extract @configKey decorators from src/config/*.ts
+// Output: docs/reference/configuration.md
+// Approach: Parse TypeScript AST, extract decorator metadata + JSDoc
+```
+
+Source: 35 `@configKey` usages across `src/config/Config.ts`, `src/config/sections/GitHub.ts`, `src/config/sections/Jira.ts`, `src/config/sections/Gitlab.ts`, etc.
+
+**Bot commands generation:**
+```typescript
+// scripts/build-commands-docs.ts
+// Extract @botCommand decorators from all Connection files
+// Output: docs/reference/bot-commands.md
+// Approach: Parse decorator arguments (prefix, help, requiredArgs, optionalArgs)
+```
+
+Source: 66 `@botCommand` usages across 12 files (`src/Connections/GithubRepo.ts`, `src/AdminRoom.ts`, `src/Connections/SetupConnection.ts`, etc.)
+
+**Event types generation:**
+```typescript
+// scripts/build-events-docs.ts
+// Grep for uk.half-shot.matrix-hookshot.* strings
+// Output: docs/reference/event-types.md
+```
+
+**Config example validation:**
+```typescript
+// scripts/validate-config-examples.ts
+// Extract YAML code blocks from docs
+// Parse and validate against BridgeConfigRoot schema
+// Report: which examples have invalid keys
+```
+
+### Snapshot testing for payloads
+
+- Store example payloads as JSON in `docs/assets/payloads/`
+- CI: validate payload JSON is parseable
+- NICE-TO-HAVE: validate against webhook schemas (e.g., `@octokit/webhooks` types for GitHub)
+
+---
+
+## 7. External Dependency Monitoring
+
+### What to track
+
+| Dependency | Current version | Track for |
+|---|---|---|
+| GitHub API | REST v3, GraphQL | Endpoint deprecations, webhook event changes |
+| GitLab API | v4 | API version changes |
+| JIRA API | v2 (server), v3 (cloud) | Server EOL changes, cloud API changes |
+| Figma API | v2 | SDK deprecation, new webhook events |
+| Matrix spec | latest | New MSCs affecting appservice API |
+| Octokit | v20 | Breaking version bumps |
+| matrix-appservice-bridge | v11 | Breaking version bumps |
+
+### Monitoring approach
+
+**MUST (MVP):**
+- `renovate.json` already exists — tracks dependency updates. Extend to flag docs-relevant updates.
+- Quarterly manual review of external API changelogs
+
+**NICE-TO-HAVE:**
+- GitHub Action that checks external doc URLs monthly, reports broken ones
+- RSS feed monitoring for Matrix spec changes (`matrix.org/blog` feed)
+
+### Update triggers
+
+When a dependency bumps in `package.json` or `Cargo.toml`:
+- CI comment: "This updates {package}. Check if docs/integrations/{service}.md needs updating."
+
+---
+
+## 8. Link Integrity System
+
+### Internal links
+
+**Tool:** `lychee` (Rust-based, fast, supports markdown)
+
+```yaml
+# .github/workflows/docs-lint.yml
+- name: Check internal links
+  run: lychee --no-progress docs/**/*.md --include-fragments
+```
+
+Runs on every PR. Blocks merge if internal links are broken.
+
+### External links
+
+**Tool:** `lychee` with external checking enabled
+
+```yaml
+# .github/workflows/docs-links.yml (weekly)
+- name: Check external links
+  run: lychee --no-progress docs/**/*.md --accept 200,301,302 --timeout 30
+```
+
+Runs weekly on a schedule. Creates issue if links are broken.
+
+### Fallback for dead links
+
+- External links include annotation: `[GitHub Webhooks docs](url) — webhook event reference`
+- If URL dies, annotation tells reader what to search for
+- `external-references/` pages serve as curated link collections — single place to update
+
+---
+
+## 9. Integration Scalability Model
+
+### Template enforcement
+
+Every integration page must match the template structure. CI validates:
+
+```typescript
+// scripts/validate-integration-pages.ts
+const REQUIRED_H2_SECTIONS = [
+  'Capabilities', 'How it works', 'Supported events', 'Authentication',
+  'Setup', 'Bot commands', 'Limitations', 'Upstream references', 'Related'
+];
+
+for (const file of glob('docs/integrations/*.md')) {
+  const headings = extractH2Headings(file);
+  for (const required of REQUIRED_H2_SECTIONS) {
+    if (!headings.includes(required)) {
+      fail(`${file}: missing required section "${required}"`);
+    }
+  }
+}
+```
+
+### Preventing duplication
+
+- Shared concepts (connections, events, auth model) live in `understand/` — integration pages LINK, never repeat
+- Shared config patterns (listeners, permissions) live in `guides/operator/` — integration setup pages reference them
+- Bot command reference is auto-generated — integration pages show examples, reference page has the full list
+
+### Adding a new integration
+
+Documented checklist in `docs/architecture/extensibility.md`:
+1. Create connection class in `src/Connections/`
+2. Copy integration template from `doc/DOCUMENTATION_ARCHITECTURE.md` section 6
+3. Fill all required sections
+4. Add to `integrations/overview.md` capability matrix
+5. Add integration slug to frontmatter validation list
+6. CI will verify template compliance
+
+---
+
+## 10. Tooling Recommendations
+
+### Documentation framework
+
+**Recommendation: VitePress**
+
+| Framework | Pros | Cons | Verdict |
+|---|---|---|---|
+| **mdBook** (current) | Simple, Rust-based, fast | No component system, limited theming, no search facets, no versioning plugin | Replace |
+| **Docusaurus** | Versioning, search, React components | Heavy, React dependency, slow builds | Overkill |
+| **VitePress** | Fast, Vue components, TypeScript-native, good search, sidebar generation, frontmatter support | Vue dependency | **Best fit** |
+| **Mintlify** | Beautiful out-of-box, API reference generation | Hosted/SaaS, less control | Not suitable for OSS |
+
+**Why VitePress:**
+- Project is TypeScript — VitePress is TypeScript-native
+- Fast builds (Vite)
+- Built-in search (MiniSearch)
+- Frontmatter-driven sidebar generation
+- Mermaid plugin available
+- Version dropdown via git tags
+- Custom Vue components for integration capability tables, evidence blocks, etc.
+
+**Migration effort:** Medium. Markdown is markdown — mostly sidebar config changes and frontmatter additions.
+
+### Linting
+
+**MUST:**
+- `markdownlint-cli2` with `.markdownlint.yml` config
+- Custom rules for hookshot-specific patterns (evidence blocks, required sections)
+
+**Config:**
+```yaml
+# .markdownlint.yml
+MD013: false      # Line length — too annoying for docs
+MD033: false      # Allow inline HTML (for callouts, badges)
+MD041: false      # First line doesn't need to be heading (frontmatter)
+```
+
+### CI/CD pipelines
+
+```yaml
+# .github/workflows/docs-lint.yml
+name: Docs Lint
+on: pull_request
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx markdownlint-cli2 "docs/**/*.md"
+      - run: npx ts-node scripts/validate-frontmatter.ts
+      - run: npx ts-node scripts/validate-integration-pages.ts
+      - run: lychee --no-progress docs/**/*.md --include-fragments
+      - run: npx ts-node scripts/validate-config-examples.ts
+```
+
+### Content generation
+
+| What | Source | Script | Output |
+|---|---|---|---|
+| Metrics reference | `src/Metrics.ts` via prom-client | `scripts/build-metrics-docs.ts` (exists) | `docs/reference/metrics.md` |
+| Config reference | `src/config/*.ts` via `@configKey` | `scripts/build-config-docs.ts` (new) | `docs/reference/configuration.md` |
+| Bot commands | `src/**/*.ts` via `@botCommand` | `scripts/build-commands-docs.ts` (new) | `docs/reference/bot-commands.md` |
+| Event types | `src/Connections/*.ts` state types | `scripts/build-events-docs.ts` (new) | `docs/reference/event-types.md` |
+| API reference | `src/widgets/BridgeWidgetApi.ts` | `scripts/build-api-docs.ts` (new) | `docs/reference/provisioning-api.md` |
+
+### Diagrams
+
+- **Mermaid** for all diagrams (inline in markdown or `.mmd` files)
+- `mermaid-cli` (`mmdc`) for CI rendering validation
+- Shared Mermaid theme in `docs/.vitepress/mermaid.config.ts`
+
+---
+
+## 11. What to Keep / Extend / Replace
+
+| Current | Decision | Reason |
+|---|---|---|
+| mdBook | **Replace** with VitePress | Limited theming, no versioning, no component system, no search facets |
+| `docs/` directory | **Keep** location, restructure contents | In-repo docs is correct |
+| `docs/SUMMARY.md` | **Replace** with VitePress sidebar config | VitePress generates sidebar from file structure + frontmatter |
+| `docs/_site/` (CSS/JS) | **Replace** with VitePress theme | Custom CSS is minimal and mdBook-specific |
+| `scripts/build-metrics-docs.ts` | **Keep and extend** pattern | Working model for auto-generation. Build similar scripts for config, commands, events. |
+| `docs-latest.yml` workflow | **Extend** with lint step | Add validation before build |
+| `book.toml` | **Remove** after migration | mdBook config |
+| `changelog.d/` + `newsfile.yml` | **Keep** | Changelog generation is separate from docs |
+| Existing doc content | **Migrate** to new structure | Content is usable, structure is not |
+
+---
+
+## 12. Governance Model
+
+### Ownership
+
+| Area | Owner | Responsibility |
+|---|---|---|
+| Doc structure + templates | Docs lead (or maintainer) | Approve structural changes, template updates |
+| Integration pages | Integration maintainer | Keep their integration page current |
+| Reference pages | Auto-generated + docs lead | Ensure generation scripts work |
+| Architecture pages | Core maintainers | Update when architecture changes |
+| Tutorials + get-started | Docs lead | Ensure they work with current version |
+
+### Review rules
+
+- **Doc-only PRs:** 1 reviewer (docs lead or any maintainer)
+- **Code + docs PRs:** Code reviewer checks code, docs lead checks docs
+- **Structural changes** (new sections, template changes): 2 reviewers
+- **Auto-generated pages:** Review the script, not the output
+
+### Quality enforcement
+
+- CI gates: lint, links, frontmatter, required sections (automated, blocks merge)
+- Review checklist: evidence, tone, accuracy (manual, enforced by reviewer)
+- Quarterly audit: check `last_verified` dates, run full external link check, compare feature inventory to docs
+
+---
+
+## 13. MVP vs Ideal
+
+### MVP (implement in 1-2 weeks)
+
+MUST:
+- [ ] Restructure `docs/` to new hierarchy (move existing files)
+- [ ] Add frontmatter to all existing pages
+- [ ] Add `markdownlint` config + CI check
+- [ ] Add `lychee` internal link check in CI
+- [ ] Extend `scripts/build-metrics-docs.ts` pattern: add `build-commands-docs.ts`
+- [ ] Write 3 hero pages: `event-lifecycle`, `integrations/overview`, `architecture/connections`
+- [ ] Add CODEOWNERS for `docs/`
+- [ ] Add PR template with docs checkbox
+
+SHOULD:
+- [ ] Write `validate-frontmatter.ts` CI check
+- [ ] Write `validate-integration-pages.ts` CI check
+- [ ] Migrate from mdBook to VitePress
+
+### Ideal (implement over 2-3 months)
+
+NICE-TO-HAVE:
+- [ ] Full auto-generation: config, commands, events, API reference
+- [ ] Config example validation against schema
+- [ ] Automated screenshot pipeline (Playwright + docker-compose)
+- [ ] External link checker on weekly schedule
+- [ ] Coverage report: code features vs documented features
+- [ ] Mermaid diagram validation in CI
+- [ ] `last_verified` staleness alerting
+- [ ] Search faceting by audience and integration
+
+---
+
+## 14. Example Pipeline: Adding a New Integration
+
+Developer adds `FooBarConnection` to `src/Connections/FooBar.ts`:
+
+### What happens automatically
+
+1. **CI detects new connection file** — `validate-integration-pages.ts` compares `src/Connections/` to `docs/integrations/`. Finds `FooBar.ts` with no matching `docs/integrations/foobar.md`. CI **warns** (not blocks — don't block code PRs on docs).
+
+2. **Bot comments on PR:** "New connection type `FooBarConnection` detected. Documentation needed at `docs/integrations/foobar.md`. Use the [integration template](doc/DOCUMENTATION_ARCHITECTURE.md#6-integration-documentation-model)."
+
+3. **Developer creates `docs/integrations/foobar.md`** from template.
+
+4. **CI validates the new page:**
+   - Frontmatter valid? (title, description, audience, integration=foobar, status) → PASS/FAIL
+   - Required sections present? (Capabilities, How it works, Auth, Setup, etc.) → PASS/FAIL
+   - Internal links resolve? → PASS/FAIL
+   - Markdown lint passes? → PASS/FAIL
+   - Integration slug added to `integrations/overview.md` capability matrix? → WARN if missing
+
+5. **Reviewer sees:** Green CI checks + structured doc page following template.
+
+### What fails if incomplete
+
+| Missing | CI result |
+|---|---|
+| No doc page at all | Warning comment, not blocking |
+| Page exists but missing required sections | **FAIL** |
+| Invalid frontmatter | **FAIL** |
+| Broken internal links | **FAIL** |
+| Missing from capability matrix | Warning |
+| No code references | Warning (reviewer-enforced) |
+| No upstream references | Warning (reviewer-enforced) |
+
+---
+
+## 15. Final Summary
+
+### How this prevents decay
+
+- **Auto-generation** for reference pages (metrics, commands, config, events) — they can't drift because they're built from code
+- **CI validation** for structure (frontmatter, required sections, links) — structural drift is caught before merge
+- **Link checking** (internal: every PR, external: weekly) — broken links are detected
+- **Coverage tracking** (connection types vs doc files) — missing docs are surfaced
+- **CODEOWNERS** — docs changes get reviewed by docs-aware people
+
+### Why it works in 1-2 years
+
+- Simple tools (`markdownlint`, `lychee`, custom TypeScript scripts) — no complex infrastructure to maintain
+- Auto-generation scripts follow the existing `build-metrics-docs.ts` pattern — proven approach
+- CI checks are fast (seconds, not minutes) — developers won't disable them
+- Governance is lightweight — quarterly audits, not daily overhead
+
+### Remaining risks
+
+- **External API changes** without clear monitoring — mitigated by quarterly review but not fully automated
+- **Prose quality** can't be automated — depends on reviewer discipline
+- **Screenshot freshness** in MVP is manual — automated pipeline is Ideal-tier
+- **VitePress migration** is a one-time effort that could block other work if not prioritized
+- **Template compliance** for existing pages requires retrofit effort

--- a/doc/DOCUMENTATION_VISUALS.md
+++ b/doc/DOCUMENTATION_VISUALS.md
@@ -1,0 +1,581 @@
+# Visual Strategy for Matrix Hookshot Documentation
+
+---
+
+## 1. Visual Philosophy
+
+**Role of visuals:** Evidence, not decoration. Every image answers: what happens, what does it look like, or how does data flow.
+
+**Trustworthy visuals:**
+- Diagrams reflect actual code paths (verified against `src/`)
+- Screenshots show real system output (not mockups)
+- Sequence diagrams match actual event handler bindings in `src/Bridge.ts`
+
+**What to avoid:**
+- Marketing-style architecture diagrams that simplify away real complexity
+- Screenshots from old versions without version annotation
+- Diagrams that show planned features as if they exist
+- Generic "cloud" boxes — name every component
+
+---
+
+## 2. Visual Language System
+
+### Diagrams
+
+**Color system:**
+| Color | Meaning | Hex |
+|---|---|---|
+| Blue | Matrix components (homeserver, rooms, clients) | `#1976D2` |
+| Green | Hookshot components (Bridge, ConnectionManager, etc.) | `#388E3C` |
+| Orange | External services (GitHub, GitLab, JIRA, etc.) | `#F57C00` |
+| Gray | Infrastructure (Redis, HTTP listeners, message queue) | `#616161` |
+| Red | Error/failure states | `#D32F2F` |
+
+**Shape types:**
+| Shape | Represents |
+|---|---|
+| Rectangle | Service or component |
+| Rounded rectangle | Process or handler |
+| Cylinder | Storage (Redis, Matrix state) |
+| Diamond | Decision point |
+| Person icon | User or bot |
+
+**Flow conventions:**
+- Left-to-right for data flow
+- Top-to-bottom for sequence/time
+- Dashed lines for async/message queue
+- Solid lines for synchronous calls
+
+**Labeling:**
+- Every arrow has a label (event name, HTTP method, or data type)
+- Components show file path: `Bridge.ts` not just "Bridge"
+- External services use their proper names and (optionally) brand icons
+
+### Screenshots
+
+**Framing rules:**
+- Crop to relevant area — no full-screen screenshots
+- Include enough context to identify where this appears (room name visible, client chrome visible)
+- Dark theme screenshots (matches Element default) unless showing theme-specific behavior
+
+**Annotations:**
+- Red arrows or boxes for callouts
+- Numbered callouts for step-by-step flows
+- Text annotations outside the screenshot, not overlaid
+
+### UI element representation
+
+| Actor | Visual treatment |
+|---|---|
+| Hookshot bot | Bot avatar + `m.notice` message styling (gray text in Element) |
+| Human user | Regular message styling |
+| External service event | Formatted notice with emoji prefix (as hookshot actually sends them) |
+| Bot command | User message starting with `!gh` or `!hookshot` prefix |
+| Error response | Red-highlighted or warning-styled message |
+
+---
+
+## 3. Visual Categories
+
+### System overview diagrams
+- **When:** `understand/` section, architecture overview
+- **Must show:** All components, their relationships, trust boundaries
+- **Style:** Component diagram with color coding
+
+### Sequence diagrams
+- **When:** Event lifecycle, integration flows, auth flows
+- **Must show:** Every participant, every message, timing order
+- **Style:** Mermaid `sequenceDiagram` with participants matching color system
+
+### Integration flow diagrams
+- **When:** Each integration page
+- **Must show:** External service → hookshot → Matrix, with specific event names
+- **Style:** Simplified sequence or flow diagram
+
+### Chatroom screenshots
+- **When:** Integration pages (showing what messages look like), tutorials
+- **Must show:** Actual Matrix client rendering of hookshot messages
+- **Style:** Cropped Element screenshots with annotations
+
+### Widget/UI screenshots
+- **When:** User guides for widget configuration
+- **Must show:** The hookshot widget UI in Element
+- **Style:** Cropped with step numbers for multi-step flows
+
+### Configuration flow diagrams
+- **When:** Operator guides
+- **Must show:** Config file → component → behavior chain
+- **Style:** Simple flow diagram
+
+### Troubleshooting visuals
+- **When:** Troubleshooting pages
+- **Must show:** Error states, log output, diagnostic commands
+- **Style:** Terminal screenshots or log excerpts in code blocks (prefer code blocks over screenshots for text)
+
+---
+
+## 4. Screenshot Strategy
+
+### Chatroom screenshots needed
+
+| Scenario | Integration | Shows |
+|---|---|---|
+| PR opened notification | GitHub | Formatted PR message with 🔵 emoji, title, author, link |
+| Issue created notification | GitHub | Formatted issue message with 📥 emoji |
+| PR review notification | GitHub | ✅ or 🔴 emoji with review verdict |
+| Push notification | GitHub | Commit count, branch, compare link |
+| `!gh create` command | GitHub | User command + bot response |
+| Emoji reaction → GitHub action | GitHub | User reacts with 🗑️, issue closes |
+| Merge request notification | GitLab | MR notification message |
+| JIRA ticket notification | JIRA | Ticket created/updated message |
+| Generic webhook message | Webhooks | Raw JSON → formatted message |
+| Transformed webhook | Webhooks | Custom transformation result |
+| RSS feed entry | Feeds | Feed notification message |
+| Bot command listing | General | `!hookshot help` output |
+
+### Widget screenshots needed
+
+| Screen | Shows |
+|---|---|
+| Connection list | Widget showing all connections in a room |
+| GitHub repo setup | Form for connecting a GitHub repo |
+| Generic webhook setup | Webhook URL display after creation |
+| Auth flow | OAuth redirect prompt |
+
+### How to generate
+
+**Test environment:**
+- Synapse (via docker-compose or Testcontainers, as existing E2E tests use)
+- Hookshot instance with test config
+- Element Web for screenshots (Playwright controls the browser)
+- Test GitHub/GitLab/JIRA accounts or mock servers
+
+**Scripting:**
+- Playwright scripts that:
+  1. Log into Element as test user
+  2. Navigate to test room
+  3. Send bot commands / trigger webhooks via HTTP
+  4. Wait for message to render
+  5. Capture screenshot of message area
+  6. Crop and annotate
+
+---
+
+## 5. Automated Screenshot Pipeline
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│  CI Pipeline (GitHub Actions)                    │
+│                                                  │
+│  1. Start Synapse + Hookshot (docker-compose)    │
+│  2. Create test rooms + connections              │
+│  3. Run scenario scripts (Playwright)            │
+│  4. Capture screenshots                          │
+│  5. Compare with stored baselines                │
+│  6. Update if intentional, fail if unexpected    │
+└─────────────────────────────────────────────────┘
+```
+
+### Environment setup
+
+```yaml
+# docker-compose.screenshots.yml
+services:
+  synapse:
+    image: matrixdotorg/synapse:latest
+    # ... test config
+  hookshot:
+    build: .
+    environment:
+      - HOOKSHOT_CONFIG=/config/test-screenshots.yml
+    depends_on: [synapse]
+  element:
+    image: vectorim/element-web:latest
+    ports: ["8080:80"]
+```
+
+### Scenario script structure
+
+```typescript
+// scripts/screenshots/github-pr-opened.ts
+import { test } from '@playwright/test';
+
+test('GitHub PR opened notification', async ({ page }) => {
+  // 1. Login to Element
+  await page.goto('http://localhost:8080');
+  await login(page, 'test-user', 'password');
+
+  // 2. Navigate to test room
+  await navigateToRoom(page, '#hookshot-test:localhost');
+
+  // 3. Trigger webhook
+  await fetch('http://localhost:9000/github/webhook', {
+    method: 'POST',
+    headers: {
+      'x-github-event': 'pull_request',
+      'x-hub-signature-256': computeSignature(payload),
+    },
+    body: JSON.stringify(prOpenedPayload),
+  });
+
+  // 4. Wait for message
+  await page.waitForSelector('.mx_EventTile:has-text("opened a new PR")');
+
+  // 5. Screenshot
+  const message = page.locator('.mx_EventTile:last-child');
+  await message.screenshot({ path: 'assets/screenshots/integration-github-pr-opened.png' });
+});
+```
+
+### Storage and versioning
+
+- Screenshots stored in `docs/assets/screenshots/` (git-tracked)
+- Naming: `{section}-{slug}[-{qualifier}].png`
+- Baseline comparison: pixel diff with threshold (e.g., 5% tolerance for font rendering)
+- Update workflow: `yarn screenshots:update` regenerates all, developer reviews diff
+
+---
+
+## 6. Scenario Library
+
+Each scenario produces screenshots + example payloads reusable across docs.
+
+### Core scenarios
+
+| ID | Scenario | Produces |
+|---|---|---|
+| `gh-pr-opened` | GitHub PR opened webhook | Screenshot + webhook payload + Matrix event |
+| `gh-issue-created` | GitHub issue created | Screenshot + payloads |
+| `gh-command-create` | `!gh create "Bug"` command | Screenshot of command + response |
+| `gh-emoji-close` | React with 🗑️ to close issue | Screenshot of reaction + confirmation |
+| `gl-mr-opened` | GitLab merge request | Screenshot + payloads |
+| `jira-ticket-created` | JIRA issue created | Screenshot + payloads |
+| `webhook-raw` | Generic webhook POST | Screenshot + payload |
+| `webhook-transform` | Webhook with transformation | Screenshot showing custom format |
+| `feed-new-entry` | RSS feed new item | Screenshot |
+| `bot-help` | `!hookshot help` | Screenshot of command listing |
+| `widget-connect` | Widget UI: connect GitHub repo | Screenshot sequence (3-4 screens) |
+| `widget-list` | Widget UI: list connections | Screenshot |
+
+### Scenario output structure
+
+```
+scenarios/
+├── gh-pr-opened/
+│   ├── scenario.ts              # Playwright script
+│   ├── webhook-payload.json     # Input webhook
+│   ├── matrix-event.json        # Resulting Matrix event
+│   ├── screenshot.png           # Captured screenshot
+│   └── README.md                # What this scenario tests
+```
+
+---
+
+## 7. Diagram Generation Strategy
+
+### Tool: Mermaid
+
+**Why Mermaid:**
+- Text-based (version controlled, diffable)
+- Renders in GitHub, most doc frameworks
+- Sufficient for sequence, flow, component, and state diagrams
+- No external tool dependency
+
+**When NOT Mermaid:**
+- Complex system context diagrams with custom positioning → SVG (hand-crafted or D2/Graphviz)
+- Diagrams needing brand icons → SVG with embedded images
+
+### Standard templates
+
+**System context template:**
+```mermaid
+graph TB
+    subgraph External["External Services (orange)"]
+        SVC1[Service 1]
+        SVC2[Service 2]
+    end
+    subgraph Hookshot["Hookshot (green)"]
+        COMP1[Component 1]
+        COMP2[Component 2]
+    end
+    HS["Matrix Homeserver (blue)"]
+    SVC1 -->|webhook| COMP1
+    COMP1 --> COMP2
+    COMP2 --> HS
+```
+
+**Event flow template:**
+```mermaid
+sequenceDiagram
+    participant EXT as External Service
+    participant WH as Webhooks.ts
+    participant MQ as MessageQueue
+    participant BR as Bridge.ts
+    participant CONN as Connection
+    participant MS as MatrixSender
+    participant HS as Homeserver
+
+    EXT->>WH: POST /service/webhook
+    WH->>MQ: emit(event)
+    MQ->>BR: deliver
+    BR->>CONN: handler(event)
+    CONN->>MS: sendMessage()
+    MS->>HS: PUT /send/m.room.message
+```
+
+**Auth flow template:**
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant M as Matrix Room
+    participant H as Hookshot
+    participant S as External Service
+
+    U->>M: !service login
+    M->>H: command received
+    H->>U: OAuth URL
+    U->>S: authorize
+    S->>H: callback with token
+    H->>M: "Logged in as X"
+```
+
+### Maintenance rules
+
+- Every diagram has a source `.mmd` file in `docs/assets/diagrams/`
+- Diagrams in docs use `include` or inline Mermaid (framework-dependent)
+- Diagram changes require PR review (visual diff in CI if possible)
+- Each diagram references the code it represents in a comment: `%% Source: src/Bridge.ts:300-500`
+
+---
+
+## 8. Visual Evidence Blocks
+
+### Embedding format
+
+```markdown
+<!-- In the doc page: -->
+
+![GitHub PR notification in Element](../assets/screenshots/integration-github-pr-opened.png)
+*A pull request notification from hookshot in an Element room. The message includes
+the PR title, author, and link. [Code: src/Connections/GithubRepo.ts:1377-1439]*
+
+```
+
+### Caption rules
+
+Every visual must have:
+1. **Alt text** (accessibility) — describes what the image shows
+2. **Caption** (below image) — explains what the reader should notice
+3. **Source reference** — code file or scenario that produced this visual
+
+### Placement rules
+
+- Screenshots appear immediately after the text that describes the behavior they show
+- Sequence diagrams appear at the start of "How it works" sections
+- System diagrams appear once per section, not repeated
+
+---
+
+## 9. Theme and Identity
+
+### Color palette
+
+| Use | Color | Hex | Notes |
+|---|---|---|---|
+| Matrix / homeserver | Blue | `#1976D2` | Matches Matrix brand |
+| Hookshot | Green | `#388E3C` | Distinct from Matrix blue |
+| External services | Orange | `#F57C00` | Warm, attention-drawing |
+| Infrastructure | Gray | `#616161` | Background, non-primary |
+| Error / danger | Red | `#D32F2F` | Warnings and failures |
+| Success | Teal | `#00897B` | Confirmations |
+
+### External service representation
+
+- Use service brand colors in their own diagrams/icons where helpful
+- In hookshot system diagrams, all external services use orange (consistency over brand fidelity)
+- Service logos may appear in the integration overview page capability matrix
+
+### Diagram tone
+
+- Technical, not illustrative
+- Labeled, not decorative
+- Minimal — show only what's needed to understand the point
+- Consistent spacing and alignment
+
+---
+
+## 10. What Breaks Over Time
+
+| Failure | Detection | Fix |
+|---|---|---|
+| Screenshots show old UI | Visual diff in CI against baselines | Re-run screenshot pipeline |
+| New UI elements not captured | Coverage check: each integration page lists required screenshots | Add to scenario library |
+| Diagrams reference renamed components | Grep diagram source files for component names | Update diagram + reference comment |
+| Color inconsistency in new diagrams | Mermaid theme config enforces palette | Define theme in `mermaid.config.json` |
+| New integration missing visuals | CI check: integration pages must have ≥1 diagram + ≥1 screenshot placeholder | Fail PR if missing |
+| External service UI changes (e.g., GitHub App setup) | These screenshots are manual — flag with `last_verified` date | Quarterly re-verification |
+
+---
+
+## 11. Tooling Recommendations
+
+| Tool | Purpose | Why |
+|---|---|---|
+| **Playwright** | Screenshot automation | Already in JS ecosystem, headless Chrome, network interception |
+| **Mermaid** | Diagram source | Text-based, git-friendly, renders everywhere |
+| **mermaid-cli** (`mmdc`) | Diagram rendering to SVG/PNG | CI rendering without browser |
+| **sharp** | Image optimization | Fast, Node.js native, auto-crop/resize |
+| **pixelmatch** | Screenshot comparison | Pixel diff for CI baseline comparison |
+| **Element Web** | Screenshot target | The primary Matrix client, represents real user experience |
+
+### CI integration
+
+```yaml
+# .github/workflows/docs-visuals.yml
+docs-screenshots:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - run: docker-compose -f docker-compose.screenshots.yml up -d
+    - run: npx playwright test scripts/screenshots/
+    - run: node scripts/compare-screenshots.js  # pixel diff against stored baselines
+    - uses: actions/upload-artifact@v4
+      with:
+        name: screenshots
+        path: docs/assets/screenshots/
+```
+
+---
+
+## 12. MVP vs Ideal
+
+### MVP (implement first)
+
+- **Mermaid diagrams** for all sequence and flow diagrams (inline in markdown)
+- **Manual screenshots** with strict naming convention and `last_verified` dates
+- **Scenario library** as documentation (JSON payloads in `assets/payloads/`)
+- **Color system** defined in a shared Mermaid theme config
+- **Evidence density targets** enforced in PR review (not CI)
+
+**Effort:** ~2 days for diagrams, ~1 day for screenshot capture, ongoing for new integrations.
+
+### Ideal (implement later)
+
+- **Automated screenshot pipeline** with Playwright + docker-compose
+- **CI baseline comparison** for screenshot regression detection
+- **Auto-generated diagrams** from code annotations (e.g., generate sequence diagrams from `bindHandlerToQueue` calls)
+- **Scenario library** that produces both screenshots and example payloads for docs
+- **Visual coverage check** in CI: every integration page must have required visuals
+
+**Effort:** ~1-2 weeks for pipeline, ongoing maintenance.
+
+---
+
+## 13. Example: GitHub PR → Matrix Message
+
+### Mermaid sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant GH as GitHub
+    participant R as Router.ts
+    participant MQ as MessageQueue
+    participant BR as Bridge.ts
+    participant CM as ConnectionManager
+    participant RC as GitHubRepoConnection
+    participant MS as MatrixSender
+    participant HS as Homeserver
+    participant RM as Matrix Room
+
+    GH->>R: POST /github/webhook<br/>x-github-event: pull_request<br/>x-hub-signature-256: sha256=...
+    R->>R: Verify HMAC-SHA256 signature
+    R->>MQ: emit("github.pull_request.opened", payload)
+    MQ->>BR: deliver to subscriber
+    BR->>CM: getConnectionsForGithubRepo("org", "repo")
+    CM-->>BR: [GitHubRepoConnection]
+    BR->>RC: onPROpened(event)
+    RC->>RC: Check enableHooks includes "pull_request.opened"
+    RC->>RC: Format: "🔵 **user** opened PR [org/repo#42](...)"
+    RC->>MS: sendMessage(roomId, {msgtype: "m.notice", ...})
+    MS->>HS: PUT /_matrix/client/v3/rooms/{roomId}/send/m.room.message
+    HS-->>RM: Message appears in room
+```
+
+Source: `src/github/Router.ts:74-99`, `src/Bridge.ts:404-413`, `src/Connections/GithubRepo.ts:1377-1439`
+
+### Screenshot plan
+
+**Scenario script:** `scenarios/gh-pr-opened/scenario.ts`
+1. Start test environment (Synapse + Hookshot + Element)
+2. Create room, connect to test GitHub repo
+3. POST mock PR webhook to `/github/webhook`
+4. Wait for message in Element
+5. Screenshot the message tile
+
+**Expected output:** A cropped Element screenshot showing:
+- Bot avatar (hookshot)
+- Message: "🔵 **octocat** opened a new PR [test-org/test-repo#42](https://github.com/...): "Fix login bug""
+- Gray `m.notice` styling
+
+### How it appears in docs
+
+```markdown
+## Example: Pull request notification
+
+When a pull request is opened on a connected repository, hookshot sends a
+formatted notification to the Matrix room.
+
+![PR notification in Element](../assets/screenshots/integration-github-pr-opened.png)
+*Pull request opened notification. Hookshot formats the message with the PR
+author, title, and link. The 🔵 emoji indicates a new PR.*
+
+The resulting Matrix event:
+
+​```json
+{
+  "type": "m.room.message",
+  "content": {
+    "msgtype": "m.notice",
+    "body": "🔵 **octocat** opened a new PR test-org/test-repo#42: \"Fix login bug\"",
+    "formatted_body": "🔵 <strong>octocat</strong> opened a new PR <a href=\"...\">test-org/test-repo#42</a>: \"Fix login bug\"",
+    "format": "org.matrix.custom.html",
+    "external_url": "https://github.com/test-org/test-repo/pull/42",
+    "uk.half-shot.matrix-hookshot.github.repo": {
+      "id": 123,
+      "full_name": "test-org/test-repo"
+    },
+    "uk.half-shot.matrix-hookshot.github.pull_request": {
+      "id": 456,
+      "number": 42,
+      "title": "Fix login bug"
+    }
+  }
+}
+​```
+
+[Code: src/Connections/GithubRepo.ts:1377-1439]
+[Scenario: scenarios/gh-pr-opened/]
+```
+
+---
+
+## 14. Final Summary
+
+**How this visual system improves understanding:**
+- Sequence diagrams show the actual event path through named source files, not abstract boxes
+- Screenshots show what users actually see in their Matrix client
+- Every visual has a code reference — readers can verify the diagram matches reality
+
+**How it builds trust:**
+- No mockups or idealized diagrams — everything is reproducible
+- Automated pipeline catches visual regressions
+- Consistent color system means readers learn the visual language once
+
+**How it stays consistent:**
+- Mermaid theme config enforces colors
+- Naming conventions prevent ad-hoc screenshot sprawl
+- CI checks enforce minimum visual evidence per page type
+- Scenario library is reusable — adding a new integration means adding scenarios, not reinventing the visual approach

--- a/doc/shortening-suggestions.md
+++ b/doc/shortening-suggestions.md
@@ -1,0 +1,164 @@
+# Shortening Suggestions
+
+Content audit of 47 documentation pages (6,207 lines total).
+Goal: cut ~20% without losing information.
+
+---
+
+## 1. Structural duplication (highest impact)
+
+### overview.md duplicates individual integration pages
+
+`integrations/overview.md` lines 50-156 contain per-service summaries (GitHub, GitLab, JIRA, etc.) that duplicate the opening sections of each individual integration page.
+
+**Current:** 107 lines of per-service prose in overview.md
+**Suggestion:** Replace with a one-line description per service linking to the full page. The capability matrix table already serves the overview purpose.
+
+**Estimated savings:** ~80 lines
+
+### what-is-hookshot.md "Next steps" duplicates "Related"
+
+Lines 111-126: "Next steps" table and "Related" section link to the same pages.
+
+**Suggestion:** Keep "Next steps" (more useful for new readers), remove "Related" section.
+
+**Estimated savings:** ~8 lines (per page — this pattern repeats on many pages)
+
+### integration-model.md overlaps with architecture/connections.md
+
+Both pages explain the Connection abstraction, lifecycle, and creation methods. integration-model.md is the user-facing version, connections.md is the contributor-facing version.
+
+**Suggestion:** Keep both but remove the lifecycle detail from integration-model.md (link to connections.md for depth). Cut lines 38-55 to a shorter version.
+
+**Estimated savings:** ~15 lines
+
+### event-lifecycle.md repeats bot commands from reference/bot-commands.md
+
+Lines 161-170: "Available commands by service" table repeats content from the auto-generated bot commands reference.
+
+**Suggestion:** Replace table with a link: "See [Bot Commands Reference](../reference/bot-commands.md) for the complete list."
+
+**Estimated savings:** ~12 lines
+
+---
+
+## 2. Verbose sections (medium impact)
+
+### architecture/connections.md — ConnectionManager section
+
+Lines 209-221: The ConnectionManager description lists 5 methods with descriptions. This is reference material, not architectural explanation.
+
+**Suggestion:** Reduce to 2 sentences + link to source code. The provisioning-api.md already covers the API surface.
+
+**Estimated savings:** ~10 lines
+
+### guides/operator/configuration.md — too much inline documentation
+
+At 310 lines, this is the longest operator guide. Several sections duplicate the config.sample.yml comments.
+
+**Suggestion:**
+- Remove the JSON log schema example (lines 46-57) — most operators don't need this
+- Shorten the permissions example (lines 155-174) — one example is enough, currently has two
+- Remove the nginx reverse proxy example (lines 108-118) — link to a recipe instead
+
+**Estimated savings:** ~40 lines
+
+### guides/operator/installation.md — registration file shown twice
+
+The registration.yml content appears both in installation.md and in the inline example. 
+
+**Suggestion:** Show it once with a link to registration.sample.yml.
+
+**Estimated savings:** ~15 lines
+
+### architecture/state-and-storage.md — interface code block
+
+Lines 96-117: Full IBridgeStorageProvider interface listing. This is source code that belongs in the repo, not docs.
+
+**Suggestion:** Replace with a 2-line summary + source link.
+
+**Estimated savings:** ~18 lines
+
+### architecture/extensibility.md — full code skeleton
+
+Lines 20-82: 62-line TypeScript code skeleton for a new connection. Useful but long.
+
+**Suggestion:** Shorten to a 20-line minimal skeleton showing only required methods. Link to GenericHook.ts as the real-world reference.
+
+**Estimated savings:** ~35 lines
+
+---
+
+## 3. Per-page wording issues
+
+### Filler transitions to cut
+
+These patterns appear across many pages and can be removed:
+
+| Pattern | Count | Action |
+|---|---|---|
+| "This page explains..." / "This page walks through..." | ~8 | Cut — the heading already says what the page is about |
+| "See [X] for more details" after already linking in the sentence | ~5 | Remove redundant "see X" |
+| "For a more detailed view..." + link | ~4 | Just the link is enough |
+| Empty ## headings followed by content | ~3 | Merge with surrounding text |
+
+### Overly cautious language
+
+| Current | Shorter |
+|---|---|
+| "This is hookshot's most distinctive architectural choice." | Cut entirely — let the reader judge |
+| "Understanding these two flows explains most of hookshot's behavior." | Cut — redundant with the heading |
+| "This is the same flow that all hookshot integrations use." | Cut — already explained above |
+| "A reader who understands the model can predict behavior they haven't seen documented." | Cut — editorial, not documentation |
+
+### Repeated explanations
+
+| Content | Appears in | Action |
+|---|---|---|
+| "Connections are stored as Matrix room state events" | what-is-hookshot, integration-model, connections, event-lifecycle, overview, configuration | Keep in integration-model + connections, cut from others (link instead) |
+| "No external database required" | what-is-hookshot, connections, evaluate, state-and-storage | Keep in connections + evaluate, cut from others |
+| "15 connection types across 8 services" | what-is-hookshot, overview, connections | Keep in overview, cut from others |
+| "QuickJS sandbox" explanation | generic-webhooks, trust-and-boundaries, hardening | Keep full version in generic-webhooks, shorten in others |
+
+---
+
+## 4. Sections that could be removed entirely
+
+| Page | Section | Lines | Reason |
+|---|---|---|---|
+| overview.md | Per-service prose (GitHub through ChallengeHound) | ~95 | Duplicates individual pages; capability matrix + connection types table is sufficient |
+| overview.md | "How connections are created" | ~14 | Already covered in integration-model.md and connections.md |
+| evaluate.md | "Architecture fit" ASCII diagram | ~12 | The what-is-hookshot.md Mermaid diagram is better |
+| what-is-hookshot.md | "Technology" section | ~6 | Useful but could move to architecture/component-model.md |
+| architecture/component-model.md | ASCII diagram | ~25 | Hard to read, the text descriptions below are clearer |
+
+---
+
+## 5. Related sections audit
+
+Every page has a "Related" section. Some are too long (10+ links) and repeat what's in the sidebar.
+
+**Suggestion:** Max 6 links per Related section. Remove links that are already in the sidebar navigation.
+
+**Estimated savings:** ~60 lines across all pages
+
+---
+
+## Summary
+
+| Category | Estimated line savings |
+|---|---|
+| Structural duplication | ~115 lines |
+| Verbose sections | ~118 lines |
+| Filler wording | ~40 lines |
+| Removable sections | ~152 lines |
+| Related section trimming | ~60 lines |
+| **Total** | **~485 lines (~8% of 6,207)** |
+
+## Priority order
+
+1. **overview.md per-service prose** — highest impact, clearest duplication
+2. **configuration.md trimming** — too long for operators who just want to get running
+3. **Related section consistency** — reduce to max 6 links everywhere
+4. **Filler wording pass** — remove "This page explains..." patterns
+5. **Code skeleton shortening** — extensibility.md, state-and-storage.md


### PR DESCRIPTION
## Summary

- Documentation architecture targeting 6 audiences (1,257 lines)
- Editorial review with 7 implementation issues and ~40 subtasks (453 lines)
- Tooling & automation strategy — CI linting, auto-generation (566 lines)
- Visual strategy — Mermaid diagrams, screenshot pipeline (581 lines)
- Content audit identifying ~485 lines (~8%) that can be cut

All planning docs live in `doc/` and have no code dependencies.

## Files

| File | Lines | Purpose |
|---|---|---|
| `doc/DOCUMENTATION_ARCHITECTURE.md` | 1,257 | Full doc structure, templates, metadata model, reading paths |
| `doc/DOCUMENTATION_REVIEW.md` | 453 | Editorial review, issue breakdown, evidence model |
| `doc/DOCUMENTATION_TOOLING.md` | 566 | Automation, CI pipelines, generation scripts |
| `doc/DOCUMENTATION_VISUALS.md` | 581 | Visual language, screenshot pipeline, diagram strategy |
| `doc/shortening-suggestions.md` | 164 | Content audit with cut suggestions |

Split from #7 into 5 independent PRs for easier review.