### PR TITLE
Docs CI: markdownlint, link checking, preview deploy

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,54 @@
+name: Docs Lint
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'scripts/build-*-docs.ts'
+      - 'scripts/validate-*.ts'
+      - '.markdownlint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Markdown lint
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: 'docs/**/*.md'
+          config: '.markdownlint.yml'
+
+      - name: Check internal links (new docs only)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --include-fragments
+            --exclude-file .lycheeexclude
+            --offline
+            docs/understand/*.md
+            docs/get-started/*.md
+            docs/integrations/*.md
+            docs/architecture/*.md
+            docs/guides/**/*.md
+            docs/reference/*.md
+            docs/troubleshooting/*.md
+            docs/project/*.md
+          fail: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: Install dependencies
+        run: yarn --ignore-scripts
+
+      - name: Validate frontmatter
+        run: npx ts-node scripts/validate-frontmatter.ts

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,64 @@
+name: Docs Preview (VitePress)
+
+on:
+  push:
+    paths:
+      - 'docs/**'
+      - 'scripts/build-*-docs.ts'
+  pull_request:
+    paths:
+      - 'docs/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: Install dependencies
+        run: yarn --ignore-scripts
+
+      - name: Determine deploy path
+        id: path
+        run: |
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          SAFE_BRANCH=$(echo "$BRANCH" | sed 's|/|-|g')
+          if [ "$BRANCH" = "main" ]; then
+            echo "base=/" >> "$GITHUB_OUTPUT"
+            echo "subdir=" >> "$GITHUB_OUTPUT"
+          else
+            echo "base=/matrix-hookshot/${SAFE_BRANCH}/" >> "$GITHUB_OUTPUT"
+            echo "subdir=${SAFE_BRANCH}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set VitePress base
+        run: |
+          BASE="${{ steps.path.outputs.base }}"
+          if [ "$BASE" != "/" ]; then
+            sed -i "s|cleanUrls: true,|cleanUrls: true,\n  base: '${BASE}',|" docs/.vitepress/config.mts
+          fi
+
+      - name: Build VitePress
+        run: npx vitepress build docs
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/.vitepress/dist
+          destination_dir: ${{ steps.path.outputs.subdir }}
+          keep_files: true

--- a/.lycheeexclude
+++ b/.lycheeexclude
@@ -1,0 +1,36 @@
+# Lychee link checker exclusions
+# See https://lychee.cli.rs/
+
+# Localhost URLs (used in config examples)
+http://localhost
+https://localhost
+http://127.0.0.1
+
+# Example domains
+https://example.com
+http://example.com
+https://hookshot.example.com
+https://ci.example.com
+https://jira.example.com
+https://jira.internal.com
+https://github.example.com
+https://your-open-project.com
+https://your-openproject.com
+
+# Matrix homeserver examples
+http://synapse
+http://localhost:8008
+http://localhost:8083
+
+# Placeholder URLs
+https://examplePublicKey@o0.ingest.sentry.io
+
+# Matrix.to links (require JS rendering)
+https://matrix.to/
+
+# GitHub API URLs (not browseable)
+https://api.github.com
+
+# Figma URLs (require auth)
+https://www.figma.com/files
+https://api.figma.com

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,56 @@
+# Markdownlint configuration for hookshot documentation
+# See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+# Line length - disabled (docs have tables and long links)
+MD013: false
+
+# Inline HTML - allowed (callouts, badges, embedded content)
+MD033: false
+
+# First line heading - disabled (frontmatter comes first)
+MD041: false
+
+# Multiple H1 headings - disabled (frontmatter title + page H1)
+MD025: false
+
+# Blanks around lists - disabled (too strict for our doc style)
+MD032: false
+
+# Fenced code language - disabled (some blocks are generic output)
+MD040: false
+
+# Ordered list prefix - disabled (mixed styles across old and new docs)
+MD029: false
+
+# Heading increment - disabled (old docs skip levels)
+MD001: false
+
+# Duplicate headings - disabled (old docs reuse "Example script" headings)
+MD024: false
+
+# Spaces in code spans - disabled (old docs have trailing spaces in backticks)
+MD038: false
+
+# Trailing punctuation in headings - disabled (old docs use periods)
+MD026: false
+
+# Dollar signs in commands - disabled (old docs use $ prefix)
+MD014: false
+
+# Blanks around headings - disabled (too strict with tables/lists after headings)
+MD022: false
+
+# Blanks around fences - disabled (tables followed by code blocks)
+MD031: false
+
+# Blanks around tables - disabled (tables in tight sections)
+MD058: false
+
+# Bare URLs - disabled (we use them in reference tables)
+MD034: false
+
+# Blank line inside blockquote - disabled (consecutive source references)
+MD028: false
+
+# Emphasis as heading - disabled (bold phase labels before diagrams)
+MD036: false

--- a/scripts/export-pdf.sh
+++ b/scripts/export-pdf.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Export documentation as PDF using vitevitepress-export-pdf.
+# Requires a running VitePress dev server.
+#
+# Usage:
+#   bash scripts/export-pdf.sh
+#
+# Output: hookshot-docs.pdf
+
+set -e
+
+echo "Starting VitePress dev server..."
+npx vitepress dev docs --port 4173 &
+DEV_PID=$!
+
+# Wait for server to be ready
+sleep 5
+for i in $(seq 1 30); do
+  curl -s http://localhost:4173 > /dev/null 2>&1 && break
+  sleep 1
+done
+
+echo "Exporting PDF..."
+npx vitepress-export-pdf export http://localhost:4173 \
+  --outFile hookshot-docs.pdf \
+  --pdfMargin "20mm" \
+  --pdfFormat "A4" \
+  --urlOrigin http://localhost:4173 \
+  2>&1 || {
+    echo "vitepress-export-pdf failed, trying alternative..."
+    # Fallback: use Playwright directly
+    npx playwright install chromium 2>/dev/null
+    node -e "
+    const { chromium } = require('playwright');
+    (async () => {
+      const browser = await chromium.launch();
+      const page = await browser.newPage();
+      await page.goto('http://localhost:4173/get-started/quickstart', { waitUntil: 'networkidle' });
+      await page.pdf({ path: 'hookshot-docs.pdf', format: 'A4', margin: { top: '20mm', bottom: '20mm', left: '15mm', right: '15mm' }, printBackground: true });
+      await browser.close();
+      console.log('PDF exported: hookshot-docs.pdf');
+    })();
+    "
+  }
+
+# Clean up
+kill $DEV_PID 2>/dev/null
+echo "Done: hookshot-docs.pdf"

--- a/scripts/validate-frontmatter.ts
+++ b/scripts/validate-frontmatter.ts
@@ -1,0 +1,161 @@
+/**
+ * Validates frontmatter in all documentation pages.
+ *
+ * Usage: ts-node scripts/validate-frontmatter.ts
+ * Exit code 0 = all valid, 1 = errors found
+ */
+
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, relative } from "path";
+
+const DOCS_DIR = join(__dirname, "..", "docs");
+
+const REQUIRED_FIELDS = ["title", "description", "audience"];
+
+const VALID_AUDIENCES = [
+  "evaluator", "user", "operator", "developer", "contributor", "architect",
+];
+
+const VALID_INTEGRATIONS = [
+  "github", "gitlab", "jira", "webhooks", "feeds", "figma",
+  "openproject", "challengehound",
+];
+
+const VALID_STATUSES = ["current", "draft", "deprecated"];
+
+interface FrontmatterError {
+  file: string;
+  error: string;
+}
+
+function parseFrontmatter(content: string): Record<string, unknown> | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  const fm: Record<string, unknown> = {};
+  const lines = match[1].split("\n");
+  let currentKey = "";
+  let inArray = false;
+  const arrayValues: string[] = [];
+
+  for (const line of lines) {
+    if (line.match(/^\s+-\s+/)) {
+      // Array item
+      const value = line.replace(/^\s+-\s+/, "").trim();
+      arrayValues.push(value);
+      if (currentKey) {
+        fm[currentKey] = [...arrayValues];
+      }
+      inArray = true;
+      continue;
+    }
+
+    if (inArray && currentKey) {
+      fm[currentKey] = [...arrayValues];
+      arrayValues.length = 0;
+      inArray = false;
+    }
+
+    const keyMatch = line.match(/^(\w+):\s*(.*)/);
+    if (keyMatch) {
+      currentKey = keyMatch[1];
+      const value = keyMatch[2].trim();
+      if (value && !value.startsWith("[")) {
+        fm[currentKey] = value.replace(/^["']|["']$/g, "");
+      } else if (value.startsWith("[")) {
+        // Inline array
+        fm[currentKey] = value
+          .replace(/^\[|\]$/g, "")
+          .split(",")
+          .map((s) => s.trim().replace(/^["']|["']$/g, ""));
+      }
+    }
+  }
+
+  if (inArray && currentKey) {
+    fm[currentKey] = [...arrayValues];
+  }
+
+  return fm;
+}
+
+function findMarkdownFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (entry.startsWith("_") || entry.startsWith(".")) continue;
+    if (statSync(full).isDirectory()) {
+      files.push(...findMarkdownFiles(full));
+    } else if (entry.endsWith(".md") && entry !== "SUMMARY.md") {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function validateFile(filePath: string): FrontmatterError[] {
+  const errors: FrontmatterError[] = [];
+  const rel = relative(DOCS_DIR, filePath);
+  const content = readFileSync(filePath, "utf-8");
+
+  const fm = parseFrontmatter(content);
+  if (!fm) {
+    errors.push({ file: rel, error: "Missing frontmatter (no --- block)" });
+    return errors;
+  }
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!fm[field]) {
+      errors.push({ file: rel, error: `Missing required field: ${field}` });
+    }
+  }
+
+  // Validate audience values
+  const audience = fm.audience;
+  if (Array.isArray(audience)) {
+    for (const a of audience) {
+      if (!VALID_AUDIENCES.includes(a as string)) {
+        errors.push({ file: rel, error: `Invalid audience: "${a}". Valid: ${VALID_AUDIENCES.join(", ")}` });
+      }
+    }
+  }
+
+  // Validate integration if present
+  if (fm.integration && !VALID_INTEGRATIONS.includes(fm.integration as string)) {
+    errors.push({ file: rel, error: `Invalid integration: "${fm.integration}". Valid: ${VALID_INTEGRATIONS.join(", ")}` });
+  }
+
+  // Validate status if present
+  if (fm.status && !VALID_STATUSES.includes(fm.status as string)) {
+    errors.push({ file: rel, error: `Invalid status: "${fm.status}". Valid: ${VALID_STATUSES.join(", ")}` });
+  }
+
+  return errors;
+}
+
+// Main
+const files = findMarkdownFiles(DOCS_DIR);
+const allErrors: FrontmatterError[] = [];
+
+// Only validate new doc pages (skip legacy docs/ pages without frontmatter)
+const newDirs = [
+  "understand", "get-started", "integrations", "architecture",
+  "guides", "reference", "troubleshooting",
+];
+
+for (const file of files) {
+  const rel = relative(DOCS_DIR, file);
+  if (newDirs.some((d) => rel.startsWith(d + "/"))) {
+    allErrors.push(...validateFile(file));
+  }
+}
+
+if (allErrors.length > 0) {
+  console.error(`\n❌ ${allErrors.length} frontmatter error(s) found:\n`);
+  for (const err of allErrors) {
+    console.error(`  ${err.file}: ${err.error}`);
+  }
+  process.exit(1);
+} else {
+  console.log(`✅ ${files.filter((f) => newDirs.some((d) => relative(DOCS_DIR, f).startsWith(d + "/"))).length} pages validated, no errors.`);
+}


### PR DESCRIPTION
## Summary

- `docs-lint.yml` workflow: markdownlint + lychee link checker on `docs/` changes
- `docs-preview.yml` workflow: deploys branch previews to GitHub Pages
- `.markdownlint.yml`: relaxed rules for doc style compatibility
- `.lycheeexclude`: known-good URL exclusions for link checker
- `validate-frontmatter.ts`: checks docs pages have required frontmatter
- `export-pdf.sh`: VitePress PDF export helper

Workflows trigger on `docs/` path changes only — safe to merge before or after the docs content PR.

Split from #7 into 5 independent PRs for easier review.