### PR TITLE
Theme comparison builder and doc utility scripts

### DIFF
--- a/scripts/build-commands-docs.ts
+++ b/scripts/build-commands-docs.ts
@@ -1,0 +1,154 @@
+/**
+ * Extracts @botCommand metadata from connection classes and generates
+ * a markdown reference page.
+ *
+ * Usage: ts-node scripts/build-commands-docs.ts > docs/reference/bot-commands.md
+ *
+ * Follows the same pattern as build-metrics-docs.ts.
+ *
+ * Note: Some connection classes have circular dependencies that prevent
+ * clean import. This script imports what it can and documents the rest
+ * from the AdminRoom which aggregates most commands.
+ */
+
+import "reflect-metadata";
+import { BotCommands } from "../src/BotCommands";
+import prettier from "prettier";
+
+// AdminRoom imports cleanly and contains admin/notification/setup commands
+import { AdminRoom } from "../src/AdminRoom";
+
+interface SourceConfig {
+  title: string;
+  prefix: string;
+  commands: BotCommands;
+}
+
+const sources: SourceConfig[] = [];
+
+// AdminRoom compiles its own commands at module level
+const adminCommands = (
+  AdminRoom as unknown as { botCommands: BotCommands }
+).botCommands;
+if (adminCommands && Object.keys(adminCommands).length > 0) {
+  sources.push({
+    title: "Admin Commands (DM with bot)",
+    prefix: "!hookshot",
+    commands: adminCommands,
+  });
+}
+
+// Try importing connection classes individually
+// These may fail due to circular dependencies
+const connectionImports: {
+  path: string;
+  exportName: string;
+  title: string;
+  prefix: string;
+}[] = [
+  {
+    path: "../src/Connections/GithubRepo",
+    exportName: "GitHubRepoConnection",
+    title: "GitHub Repository Commands",
+    prefix: "!gh",
+  },
+  {
+    path: "../src/Connections/GitlabRepo",
+    exportName: "GitLabRepoConnection",
+    title: "GitLab Repository Commands",
+    prefix: "!gl",
+  },
+  {
+    path: "../src/Connections/JiraProject",
+    exportName: "JiraProjectConnection",
+    title: "JIRA Project Commands",
+    prefix: "!jira",
+  },
+  {
+    path: "../src/Connections/OpenProjectConnection",
+    exportName: "OpenProjectConnection",
+    title: "OpenProject Commands",
+    prefix: "!op",
+  },
+];
+
+for (const ci of connectionImports) {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require(ci.path);
+    const cls = mod[ci.exportName];
+    if (cls?.botCommands && Object.keys(cls.botCommands).length > 0) {
+      sources.push({
+        title: ci.title,
+        prefix: ci.prefix,
+        commands: cls.botCommands,
+      });
+    }
+  } catch {
+    // Connection class has circular deps — add a note instead
+    sources.push({
+      title: ci.title,
+      prefix: ci.prefix,
+      commands: {},
+    });
+  }
+}
+
+let totalCommands = 0;
+let output = `---
+title: Bot Commands Reference
+description: Complete reference of all hookshot bot commands
+audience: [user, operator]
+generated_from: "scripts/build-commands-docs.ts"
+---
+
+# Bot Commands Reference
+
+This page is auto-generated from \`@botCommand\` decorators in the source code.
+
+To regenerate: \`ts-node scripts/build-commands-docs.ts > docs/reference/bot-commands.md\`
+
+`;
+
+const summaryCounts: { title: string; count: number }[] = [];
+
+for (const source of sources) {
+  const entries = Object.entries(source.commands);
+  if (entries.length === 0) {
+    output += `## ${source.title}\n\n`;
+    output += `Prefix: \`${source.prefix}\`\n\n`;
+    output += `> Commands could not be auto-extracted due to module dependencies. See source code for the full list.\n\n`;
+    continue;
+  }
+
+  totalCommands += entries.length;
+  summaryCounts.push({ title: source.title, count: entries.length });
+
+  output += `## ${source.title}\n\n`;
+  output += `Prefix: \`${source.prefix}\`\n\n`;
+  output += `| Command | Required args | Optional args | Description |\n`;
+  output += `|---------|---------------|---------------|-------------|\n`;
+
+  for (const [prefix, cmd] of entries) {
+    const required =
+      cmd.requiredArgs?.map((a) => `\`<${a}>\``).join(" ") || "—";
+    const optional =
+      cmd.optionalArgs?.map((a) => `\`[${a}]\``).join(" ") || "—";
+    output += `| \`${source.prefix} ${prefix}\` | ${required} | ${optional} | ${cmd.help} |\n`;
+  }
+  output += "\n";
+}
+
+output += `## Summary\n\n`;
+output += `Total auto-extracted commands: **${totalCommands}**\n\n`;
+if (summaryCounts.length > 0) {
+  output += `| Source | Count |\n`;
+  output += `|--------|-------|\n`;
+  for (const entry of summaryCounts) {
+    output += `| ${entry.title} | ${entry.count} |\n`;
+  }
+}
+
+prettier
+  .format(output, { parser: "markdown" })
+  .then((s: string) => process.stdout.write(s));

--- a/scripts/build-theme-comparison.sh
+++ b/scripts/build-theme-comparison.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Build the docs with many different themes for side-by-side comparison.
+# Output: docs-themes/<theme-name>/
+#
+# Usage: bash scripts/build-theme-comparison.sh [--quick]
+#   --quick: build only 15 representative themes (faster)
+#   default: build all ~50 themes
+
+set -e
+
+DOCS_DIR="docs"
+THEME_FILE="$DOCS_DIR/.vitepress/theme/index.ts"
+CONFIG_FILE="$DOCS_DIR/.vitepress/config.mts"
+OUTPUT_BASE="docs-themes"
+
+cp "$THEME_FILE" "${THEME_FILE}.bak"
+cp "$CONFIG_FILE" "${CONFIG_FILE}.bak"
+
+cleanup() {
+  mv "${THEME_FILE}.bak" "$THEME_FILE" 2>/dev/null || true
+  mv "${CONFIG_FILE}.bak" "$CONFIG_FILE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Format: name|type|flavor|accent|dark_hl|light_hl
+# type: default (no CSS override), catppuccin (CSS import)
+THEMES=()
+
+# === DEFAULT VITEPRESS with different syntax highlighting ===
+THEMES+=(
+  "default-github|default|none|none|github-dark|github-light"
+  "default-dimmed|default|none|none|github-dark-dimmed|github-light"
+  "default-dracula|default|none|none|dracula|github-light"
+  "default-nord|default|none|none|nord|github-light"
+  "default-one-dark|default|none|none|one-dark-pro|one-light"
+  "default-tokyo-night|default|none|none|tokyo-night|github-light"
+  "default-material-ocean|default|none|none|material-theme-ocean|material-theme-lighter"
+  "default-rose-pine|default|none|none|rose-pine|rose-pine-dawn"
+  "default-vitesse|default|none|none|vitesse-dark|vitesse-light"
+  "default-monokai|default|none|none|monokai|github-light"
+  "default-synthwave|default|none|none|synthwave-84|github-light"
+  "default-solarized|default|none|none|solarized-dark|solarized-light"
+  "default-everforest|default|none|none|everforest-dark|everforest-light"
+  "default-poimandres|default|none|none|poimandres|github-light"
+  "default-night-owl|default|none|none|night-owl|github-light"
+  "default-kanagawa|default|none|none|kanagawa-wave|kanagawa-lotus"
+  "default-houston|default|none|none|houston|github-light"
+  "default-aurora|default|none|none|aurora-x|github-light"
+  "default-slack|default|none|none|slack-dark|slack-ochin"
+  "default-snazzy|default|none|none|min-dark|snazzy-light"
+)
+
+# === CATPPUCCIN MOCHA (warm dark) — all 14 accents ===
+for accent in blue flamingo green lavender maroon mauve peach pink red rosewater sapphire sky teal yellow; do
+  THEMES+=("mocha-${accent}|catppuccin|mocha|${accent}|catppuccin-mocha|catppuccin-latte")
+done
+
+# === CATPPUCCIN FRAPPÉ (mid-tone) — 6 best accents ===
+for accent in blue green lavender mauve sapphire teal; do
+  THEMES+=("frappe-${accent}|catppuccin|frappe|${accent}|catppuccin-frappe|catppuccin-latte")
+done
+
+# === CATPPUCCIN MACCHIATO (cool dark) — 6 best accents ===
+for accent in blue green lavender mauve peach sapphire; do
+  THEMES+=("macchiato-${accent}|catppuccin|macchiato|${accent}|catppuccin-macchiato|catppuccin-latte")
+done
+
+# Quick mode: only build representative subset
+if [ "$1" = "--quick" ]; then
+  QUICK_NAMES="default-github default-dracula default-nord default-tokyo-night default-rose-pine default-vitesse default-solarized default-everforest mocha-green mocha-blue mocha-mauve mocha-pink frappe-blue frappe-green macchiato-blue"
+  FILTERED=()
+  for entry in "${THEMES[@]}"; do
+    name="${entry%%|*}"
+    for q in $QUICK_NAMES; do
+      [ "$name" = "$q" ] && FILTERED+=("$entry") && break
+    done
+  done
+  THEMES=("${FILTERED[@]}")
+  echo "Quick mode: building ${#THEMES[@]} themes"
+fi
+
+rm -rf "$OUTPUT_BASE"
+mkdir -p "$OUTPUT_BASE"
+
+TOTAL=${#THEMES[@]}
+CURRENT=0
+FAILED=0
+
+for entry in "${THEMES[@]}"; do
+  IFS='|' read -r name type flavor accent dark_hl light_hl <<< "$entry"
+  CURRENT=$((CURRENT + 1))
+  echo ""
+  echo "=== [$CURRENT/$TOTAL] $name ==="
+
+  # Restore config from backup (clean slate)
+  cp "${CONFIG_FILE}.bak" "$CONFIG_FILE"
+
+  # Write theme file
+  case "$type" in
+    default)
+      cat > "$THEME_FILE" << 'EOF'
+import DefaultTheme from 'vitepress/theme'
+export default DefaultTheme
+EOF
+      ;;
+    catppuccin)
+      cat > "$THEME_FILE" << EOF
+import DefaultTheme from 'vitepress/theme'
+import '@catppuccin/vitepress/theme/${flavor}/${accent}.css'
+export default DefaultTheme
+EOF
+      ;;
+  esac
+
+  # Set syntax highlighting and base path
+  sed -i "s/dark: '.*'/dark: '${dark_hl}'/" "$CONFIG_FILE"
+  sed -i "s/light: '.*'/light: '${light_hl}'/" "$CONFIG_FILE"
+  sed -i "s|cleanUrls: true,|cleanUrls: true,\n  base: '/${name}/',|" "$CONFIG_FILE"
+
+  THEME_OUT="$OUTPUT_BASE/$name"
+  if npx vitepress build "$DOCS_DIR" --outDir "$(pwd)/$THEME_OUT" 2>&1 | tail -1; then
+    echo "    ✅ $name"
+  else
+    echo "    ❌ FAILED: $name"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+echo ""
+echo "=== $((TOTAL - FAILED))/$TOTAL themes built ==="
+echo "Output: $OUTPUT_BASE/"
+echo ""
+echo "Next: bash scripts/build-theme-index.sh"

--- a/scripts/build-theme-index.sh
+++ b/scripts/build-theme-index.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+# Generate theme comparison HTML from whatever themes were built.
+# Auto-discovers themes from docs-themes/ subdirectories.
+#
+# Usage: bash scripts/build-theme-index.sh
+
+OUTPUT_BASE="docs-themes"
+
+# Auto-discover built themes
+THEME_DIRS=$(find "$OUTPUT_BASE" -maxdepth 1 -mindepth 1 -type d | sort)
+THEME_COUNT=$(echo "$THEME_DIRS" | wc -l)
+
+echo "Found $THEME_COUNT themes"
+
+# Build JSON array of themes
+THEMES_JSON="["
+FIRST=true
+for dir in $THEME_DIRS; do
+  name=$(basename "$dir")
+  # Determine family
+  if [[ "$name" == mocha-* ]]; then family="mocha"; label="Mocha ${name#mocha-}"
+  elif [[ "$name" == frappe-* ]]; then family="frappe"; label="Frappé ${name#frappe-}"
+  elif [[ "$name" == macchiato-* ]]; then family="macchiato"; label="Macchiato ${name#macchiato-}"
+  elif [[ "$name" == default-* ]]; then family="default"; label="Default (${name#default-})"
+  else family="other"; label="$name"
+  fi
+  # Capitalize accent
+  label=$(echo "$label" | sed 's/-/ /g' | sed 's/\b\(.\)/\u\1/g')
+
+  [ "$FIRST" = true ] && FIRST=false || THEMES_JSON+=","
+  THEMES_JSON+="{\"name\":\"$name\",\"label\":\"$label\",\"family\":\"$family\"}"
+done
+THEMES_JSON+="]"
+
+cat > "$OUTPUT_BASE/index.html" << HTMLEOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hookshot Docs — Theme Showcase ($THEME_COUNT themes)</title>
+  <style>
+    :root {
+      --bg: #1e1e2e; --surface: #181825; --border: #313244;
+      --text: #cdd6f4; --subtext: #a6adc8; --accent: #a6e3a1;
+      --accent2: #89b4fa; --card-bg: #1e1e2e;
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif; background: var(--bg); color: var(--text); }
+    .container { max-width: 1800px; margin: 0 auto; padding: 2rem; }
+    header { text-align: center; padding: 3rem 1rem 2rem; }
+    h1 { font-size: 2.8rem; font-weight: 800;
+      background: linear-gradient(135deg, var(--accent), var(--accent2), #f5c2e7);
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+    .subtitle { color: var(--subtext); font-size: 1.15rem; margin-top: 0.5rem; }
+    .stats { display: flex; justify-content: center; gap: 2rem; margin: 1.5rem 0; }
+    .stat { text-align: center; }
+    .stat-num { font-size: 2.2rem; font-weight: 700; color: var(--accent); }
+    .stat-label { font-size: 0.85rem; color: var(--subtext); }
+
+    .controls { display: flex; justify-content: center; gap: 0.5rem; margin: 1rem 0; flex-wrap: wrap; }
+    .controls button { padding: 0.5rem 1.2rem; border: 1px solid var(--border); background: transparent;
+      color: var(--subtext); border-radius: 20px; cursor: pointer; font-size: 0.9rem; transition: all 0.2s; }
+    .controls button:hover { color: var(--text); border-color: var(--accent2); }
+    .controls button.active { background: var(--accent2); color: var(--bg); border-color: var(--accent2); font-weight: 600; }
+
+    .tab-bar { display: flex; justify-content: center; gap: 0.5rem; margin: 1.5rem 0; }
+    .tab-bar button { padding: 0.6rem 1.5rem; border: 1px solid var(--border); background: transparent;
+      color: var(--text); border-radius: 8px; cursor: pointer; font-size: 0.95rem; transition: all 0.2s; }
+    .tab-bar button:hover { border-color: var(--accent); }
+    .tab-bar button.active { background: var(--accent); color: var(--bg); border-color: var(--accent); font-weight: 600; }
+
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: 1.2rem; }
+    .card { border: 1px solid var(--border); border-radius: 14px; overflow: hidden;
+      background: var(--surface); transition: all 0.3s; }
+    .card:hover { transform: translateY(-4px); box-shadow: 0 8px 24px rgba(0,0,0,0.4); border-color: var(--accent); }
+    .card iframe { width: 100%; height: 300px; border: none; pointer-events: none; }
+    .card-info { padding: 0.8rem 1rem; display: flex; justify-content: space-between; align-items: center;
+      border-top: 1px solid var(--border); }
+    .card-info h3 { font-size: 0.95rem; font-weight: 600; }
+    .badge { font-size: 0.7rem; padding: 0.15rem 0.5rem; border-radius: 10px;
+      background: var(--border); color: var(--subtext); margin-left: 0.5rem; }
+    .card-actions a { color: var(--accent2); text-decoration: none; font-size: 0.85rem;
+      padding: 0.3rem 0.8rem; border: 1px solid var(--border); border-radius: 8px; transition: all 0.2s; }
+    .card-actions a:hover { background: var(--accent2); color: var(--bg); }
+
+    .compare-controls { text-align: center; padding: 1rem; display: none; }
+    .compare-controls select, .compare-controls button {
+      padding: 0.5rem 1rem; font-size: 0.95rem; border-radius: 8px; margin: 0 0.3rem; }
+    .compare-controls select { border: 1px solid var(--border); background: var(--surface); color: var(--text); }
+    .compare-controls > button { border: none; background: var(--accent); color: var(--bg); cursor: pointer; font-weight: 600; }
+    .compare-view { display: none; }
+    .compare-view.active { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+    .compare-view iframe { width: 100%; height: 85vh; border: 1px solid var(--border); border-radius: 12px; }
+    .compare-label { text-align: center; padding: 0.5rem; font-weight: 600; color: var(--accent); }
+
+    .hidden { display: none !important; }
+    .size-controls { display: flex; justify-content: center; gap: 0.5rem; margin: 0.5rem 0; }
+    .size-controls button { padding: 0.3rem 0.8rem; font-size: 0.8rem; border: 1px solid var(--border);
+      background: transparent; color: var(--subtext); border-radius: 6px; cursor: pointer; }
+    .size-controls button.active { background: var(--border); color: var(--text); }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Hookshot Docs — Theme Showcase</h1>
+      <p class="subtitle">47 documentation pages rendered in $THEME_COUNT different themes</p>
+      <div class="stats">
+        <div class="stat"><div class="stat-num">$THEME_COUNT</div><div class="stat-label">Themes</div></div>
+        <div class="stat"><div class="stat-num">47</div><div class="stat-label">Pages</div></div>
+        <div class="stat"><div class="stat-num">20</div><div class="stat-label">Syntax Themes</div></div>
+        <div class="stat"><div class="stat-num">26</div><div class="stat-label">Catppuccin Variants</div></div>
+      </div>
+    </header>
+
+    <div class="tab-bar">
+      <button class="active" onclick="showView('gallery',this)">Gallery</button>
+      <button onclick="showView('compare',this)">Side-by-Side</button>
+    </div>
+
+    <div class="controls" id="family-filter"></div>
+
+    <div class="size-controls" id="size-controls">
+      Preview: <button onclick="setSize(250,this)">S</button>
+      <button class="active" onclick="setSize(300,this)">M</button>
+      <button onclick="setSize(450,this)">L</button>
+      <button onclick="setSize(600,this)">XL</button>
+    </div>
+
+    <div class="grid" id="gallery"></div>
+
+    <div class="compare-controls" id="compare-controls">
+      <select id="left-theme"></select>
+      <span style="color:var(--subtext)">vs</span>
+      <select id="right-theme"></select>
+      <select id="compare-page">
+        <option value="index.html">Home</option>
+        <option value="understand/event-lifecycle">Event Lifecycle</option>
+        <option value="integrations/overview">Integrations</option>
+        <option value="integrations/github">GitHub</option>
+        <option value="architecture/connections">Connections</option>
+        <option value="guides/operator/configuration">Configuration</option>
+        <option value="troubleshooting/webhooks-not-arriving">Troubleshooting</option>
+        <option value="get-started/quickstart">Quickstart</option>
+        <option value="reference/bot-commands">Bot Commands</option>
+        <option value="project/ecosystem">Ecosystem</option>
+        <option value="project/limitations">Limitations</option>
+      </select>
+      <button onclick="loadComparison()">Compare</button>
+    </div>
+
+    <div class="compare-view" id="compare-view">
+      <div><div class="compare-label" id="left-label"></div><iframe id="left-frame"></iframe></div>
+      <div><div class="compare-label" id="right-label"></div><iframe id="right-frame"></iframe></div>
+    </div>
+  </div>
+
+  <script>
+    const themes = $THEMES_JSON;
+
+    const previewPages = [
+      'integrations/github', 'understand/event-lifecycle', 'architecture/connections',
+      'get-started/quickstart', 'integrations/overview', 'guides/operator/configuration',
+      'project/ecosystem', 'troubleshooting/webhooks-not-arriving', 'reference/bot-commands',
+      'integrations/generic-webhooks'
+    ];
+    const pp = i => previewPages[i % previewPages.length];
+
+    // Discover families
+    const families = [...new Set(themes.map(t => t.family))];
+
+    // Build family filter
+    const filterBar = document.getElementById('family-filter');
+    filterBar.innerHTML = '<button class="active" onclick="filterThemes(\'all\',this)">All (' + themes.length + ')</button>';
+    families.forEach(f => {
+      const count = themes.filter(t => t.family === f).length;
+      filterBar.innerHTML += '<button onclick="filterThemes(\\''+f+'\\',this)">' +
+        f.charAt(0).toUpperCase() + f.slice(1) + ' (' + count + ')</button>';
+    });
+
+    // Build gallery
+    const gallery = document.getElementById('gallery');
+    themes.forEach((t, i) => {
+      const card = document.createElement('div');
+      card.className = 'card';
+      card.dataset.family = t.family;
+      card.innerHTML =
+        '<iframe src="' + t.name + '/' + pp(i) + '" loading="lazy"></iframe>' +
+        '<div class="card-info"><div><h3>' + t.label +
+        '<span class="badge">' + t.family + '</span></h3></div>' +
+        '<div class="card-actions"><a href="' + t.name + '/index.html" target="_blank">Browse ↗</a></div></div>';
+      gallery.appendChild(card);
+    });
+
+    // Build selects
+    const leftSel = document.getElementById('left-theme');
+    const rightSel = document.getElementById('right-theme');
+    themes.forEach((t, i) => {
+      const opt = '<option value="' + t.name + '">' + t.label + '</option>';
+      leftSel.innerHTML += opt;
+      rightSel.innerHTML += opt;
+    });
+    leftSel.selectedIndex = 0;
+    rightSel.selectedIndex = Math.min(2, themes.length - 1);
+
+    function showView(view, btn) {
+      document.querySelectorAll('.tab-bar button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      gallery.style.display = view === 'gallery' ? 'grid' : 'none';
+      document.getElementById('family-filter').style.display = view === 'gallery' ? 'flex' : 'none';
+      document.getElementById('size-controls').style.display = view === 'gallery' ? 'flex' : 'none';
+      document.getElementById('compare-view').className = view === 'compare' ? 'compare-view active' : 'compare-view';
+      document.getElementById('compare-controls').style.display = view === 'compare' ? 'block' : 'none';
+      if (view === 'compare') loadComparison();
+    }
+
+    function filterThemes(family, btn) {
+      document.querySelectorAll('#family-filter button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      document.querySelectorAll('.card').forEach(c => {
+        c.classList.toggle('hidden', family !== 'all' && c.dataset.family !== family);
+      });
+    }
+
+    function setSize(h, btn) {
+      document.querySelectorAll('.size-controls button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      document.querySelectorAll('.card iframe').forEach(f => f.style.height = h + 'px');
+    }
+
+    function loadComparison() {
+      const l = leftSel.value, r = rightSel.value;
+      const page = document.getElementById('compare-page').value;
+      document.getElementById('left-frame').src = l + '/' + page;
+      document.getElementById('right-frame').src = r + '/' + page;
+      document.getElementById('left-label').textContent = leftSel.options[leftSel.selectedIndex].text;
+      document.getElementById('right-label').textContent = rightSel.options[rightSel.selectedIndex].text;
+    }
+  </script>
+</body>
+</html>
+HTMLEOF
+
+echo "✅ Theme comparison: $OUTPUT_BASE/index.html ($THEME_COUNT themes)"
+echo "   Serve: npx serve $OUTPUT_BASE"

--- a/scripts/convert-evidence.sh
+++ b/scripts/convert-evidence.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Convert hidden <!-- Code: ... --> comments to visible GitHub source links.
+# Usage: bash scripts/convert-evidence.sh
+#
+# Converts <!-- Code: src/Bridge.ts:299-1023 --> to visible blockquote with link.
+# Handles descriptions in parentheses, multiple comma-separated refs.
+
+set -e
+
+REPO_URL="https://github.com/matrix-org/matrix-hookshot/blob/main"
+DOCS_DIRS="docs/understand docs/get-started docs/integrations docs/architecture docs/guides/operator docs/reference docs/troubleshooting docs/project"
+
+# Use Python for reliable parsing
+python3 << 'PYEOF'
+import re, os, glob
+
+REPO_URL = "https://github.com/matrix-org/matrix-hookshot/blob/main"
+DIRS = "docs/understand docs/get-started docs/integrations docs/architecture docs/guides/operator docs/reference docs/troubleshooting docs/project".split()
+
+# Match: src/path/File.ts:123-456 with optional (description)
+REF_PATTERN = re.compile(r'(src/[\w/.-]+(?::\d+(?:-\d+)?)?)\s*(?:\([^)]*\))?')
+
+def make_link(ref):
+    """Convert a source reference to a GitHub permalink."""
+    # Extract path and optional line numbers
+    match = re.match(r'(src/[\w/.-]+?)(?::(\d+)(?:-(\d+))?)?$', ref.strip())
+    if not match:
+        return None
+    path, start, end = match.groups()
+    if start and end:
+        return f'[`{path}:{start}-{end}`]({REPO_URL}/{path}#L{start}-L{end})'
+    elif start:
+        return f'[`{path}:{start}`]({REPO_URL}/{path}#L{start})'
+    else:
+        return f'[`{path}`]({REPO_URL}/{path})'
+
+def convert_comment(comment_text):
+    """Convert a <!-- Code: ... --> comment to a visible source blockquote."""
+    # Strip the comment markers
+    inner = comment_text.replace('<!-- Code:', '').replace('-->', '').strip()
+
+    # Find all src/ references
+    refs = REF_PATTERN.findall(inner)
+    if not refs:
+        # Non-src references (like @botCommand decorators) — keep as note
+        return f'> **Source:** {inner}'
+
+    links = []
+    for ref in refs:
+        link = make_link(ref)
+        if link:
+            links.append(link)
+
+    if not links:
+        return f'> **Source:** {inner}'
+
+    return '> **Source:** ' + ' · '.join(links)
+
+total = 0
+converted = 0
+
+for d in DIRS:
+    for pattern in [f'{d}/*.md', f'{d}/**/*.md']:
+        for filepath in glob.glob(pattern, recursive=True):
+            with open(filepath, 'r') as f:
+                lines = f.readlines()
+
+            new_lines = []
+            changed = False
+            for line in lines:
+                if '<!-- Code:' in line and '-->' in line:
+                    total += 1
+                    comment = line.strip()
+                    replacement = convert_comment(comment)
+                    new_lines.append(replacement + '\n')
+                    changed = True
+                    converted += 1
+                elif '<!-- Assumption' in line and '-->' in line:
+                    total += 1
+                    inner = line.strip().replace('<!--', '').replace('-->', '').strip()
+                    new_lines.append(f'> ⚠️ **{inner}**\n')
+                    changed = True
+                    converted += 1
+                elif '<!-- Note:' in line and '-->' in line:
+                    total += 1
+                    inner = line.strip().replace('<!-- Note:', '').replace('-->', '').strip()
+                    new_lines.append(f'> **Note:** {inner}\n')
+                    changed = True
+                    converted += 1
+                else:
+                    new_lines.append(line)
+
+            if changed:
+                with open(filepath, 'w') as f:
+                    f.writelines(new_lines)
+                print(f'  ✅ {filepath} ({sum(1 for l in new_lines if l.startswith("> **Source:**"))} refs)')
+
+print(f'\n=== Converted {converted} of {total} hidden comments to visible evidence ===')
+PYEOF


### PR DESCRIPTION
## Summary

- `build-theme-comparison.sh`: builds VitePress in 15 (quick) or 46 (full) Catppuccin theme variants
- `build-theme-index.sh`: generates HTML gallery with filter buttons for side-by-side comparison
- `build-commands-docs.ts`: generates bot commands reference from `@botCommand` annotations
- `convert-evidence.sh`: converts hidden code comments to visible GitHub source links

All scripts are standalone utilities — they don't run automatically and can be merged independently.

Split from #7 into 5 independent PRs for easier review.